### PR TITLE
Persistent Undo for CLI vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -49,12 +49,10 @@ set nowb
 
 " ================ Persistent Undo ==================
 " Keep undo history across sessions, by storing in file.
-" Only works in MacVim (gui) mode.
+" Only works all the time.
 
-if has('gui_running')
-  set undodir=~/.vim/backups
-  set undofile
-endif
+set undodir=~/.vim/backups
+set undofile
 
 " ================ Indentation ======================
 

--- a/zsh/aliases
+++ b/zsh/aliases
@@ -29,6 +29,9 @@ alias lsg='ll | grep'
 alias ae='vi $yadr/zsh/aliases' #alias edit
 alias ar='source $yadr/zsh/aliases'  #alias reload
 
+# vim using
+alias vim=$(brew ls macvim | grep Contents/MacOS/Vim)
+
 # vimrc editing
 alias ve='vi ~/.vimrc'
 


### PR DESCRIPTION
aliases 'vim' to the macvim vim binary in the homebrew cellar for persistent undo. Also had to create the backups directory, not sure what to change in the repo to effect that on install.
