### PR TITLE
Fix stray backtick causing installer errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ task :install => [:submodules] do
         end
       end
       FileUtils.rm_rf(target) if overwrite || overwrite_all
-      run %{ mv "$HOME/.#{file}" "$HOME/.#{file}.backup"` if backup || backup_all }
+      run %{ mv "$HOME/.#{file}" "$HOME/.#{file}.backup" } if backup || backup_all
     end
     run %{ ln -s "#{source}" "#{target}" }
   end


### PR DESCRIPTION
There's a stray backtick in the Rakefile which causes the installer to
fail copying files. This commit removes the backtick and relocates a
right brace to make everything work properly.
