### PR TITLE
Fix excludes file in gitconfig

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -98,7 +98,7 @@
 [core]
   autocrlf = false
   editor = vim
-  excludesfile = ~/.yadr/gitignore_global
+  excludesfile = ~/.yadr/git/gitignore
 [advice]
   statusHints = false
 [diff]


### PR DESCRIPTION
It was pointing to .yadr/gitignore_global, a symlink that no longer
exits. Point it to .yadr/git/gitignore instead.
