### PR TITLE
Incorrect PATH to Google Chrome's Custom CSS.

### DIFF
--- a/chrome/install.sh
+++ b/chrome/install.sh
@@ -3,4 +3,5 @@
 # http://blog.dotsmart.net/2011/09/30/change-font-size-in-chrome-devtools/
 
 # Use:
-cp ~/.yadr/chrome/Custom.css ~/Library/Application\ Support/Google/Chrome/Default/Custom.css
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+ln -s -f $DIR/Custom.css $HOME/Library/Application\ Support/Google/Chrome/Default/User\ StyleSheets/Custom.css


### PR DESCRIPTION
Missing 'User Stylesheets' folder.

On the way:
- Changed the directory location to a relative path.
- Created a symlink instead of copying the stylesheet.
