### PR TITLE
Handle homebrew sbin executables

### DIFF
--- a/zsh/0_path.zsh
+++ b/zsh/0_path.zsh
@@ -1,3 +1,3 @@
 # path, the 0 in the filename causes this to load first
-export PATH=/usr/local/bin:$PATH:$yadr/bin:$yadr/bin/yadr
+export PATH=/usr/local/sbin:/usr/local/bin:$PATH:$yadr/bin:$yadr/bin/yadr
 


### PR DESCRIPTION
Homebrew put all his executables in /usr/local/bin and /usr/local/sbin. This pull request tries to handle the second case
