### PR TITLE
Allowing theme change via before files when using sorin's OMZ

### DIFF
--- a/zsh/omz-sorin/omz-sorin.zsh
+++ b/zsh/omz-sorin/omz-sorin.zsh
@@ -29,7 +29,7 @@ zstyle ':omz:load' omodule 'environment' 'terminal' 'editor' 'completion' \
 # Set the prompt theme to load.
 # Setting it to 'random' loads a random theme.
 # Auto set to 'off' on dumb terminals.
-zstyle ':omz:module:prompt' theme 'skwp'
+zstyle ':omz:module:prompt' theme $ZSH_THEME
 
 # This will make you shout: OH MY ZSHELL!
 source "$OMZ/init.zsh"


### PR DESCRIPTION
Previously when using Sorin's OMZ setting the ZSH_THEME in a before config had no effect.
