### PR TITLE
1st stab at unattended installation.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,43 @@
+require 'pathname'
 require 'rake'
+require 'yaml'
+
+@answers_file = Pathname.new('answers.yml')
+@answers = {}
+questions = {
+  git_configs: 'git configs (color, aliases)',
+  irb_pry_configs: 'irb/pry configs (more colorful)',
+  rubygems_config: 'rubygems config (faster/no docs)',
+  ctags_config: 'ctags config (better js/ruby support)',
+  vimify_command_line_tools: 'vimification of command line tools',
+  vim_config: 'vim configuration (highly recommended)',
+  zsh_enhancements_and_prezto: 'zsh enhancements & prezto'
+}
 
 desc "Hook our dotfiles into system-standard positions."
 task :install => [:submodules] do
-  puts
-  puts "======================================================"
-  puts "Welcome to YADR Installation. I'll ask you a few"
-  puts "questions about which files to install. Nothing will"
-  puts "be overwritten without your consent."
-  puts "======================================================"
-  puts
-  # this has all the runcoms from this directory.
-  file_operation(Dir.glob('git/*')) if want_to_install?('git configs (color, aliases)')
-  file_operation(Dir.glob('irb/*')) if want_to_install?('irb/pry configs (more colorful)')
-  file_operation(Dir.glob('ruby/*')) if want_to_install?('rubygems config (faster/no docs)')
-  file_operation(Dir.glob('ctags/*')) if want_to_install?('ctags config (better js/ruby support)')
-  file_operation(Dir.glob('vimify/*')) if want_to_install?('vimification of command line tools')
-  file_operation(Dir.glob('{vim,vimrc}')) if want_to_install?('vim configuration (highly recommended)')
+  installation_mode = @answers_file.exists? :unattended : :interactive
 
-  if want_to_install?('zsh enhancements & prezto')
+  if installation_mode == :interactive
+    puts
+    puts "======================================================"
+    puts "Welcome to YADR Installation. I'll ask you a few"
+    puts "questions about which files to install. Nothing will"
+    puts "be overwritten without your consent."
+    puts "======================================================"
+    puts
+  else
+    @answers = process_answers_file
+  end
+  # this has all the runcoms from this directory.
+  file_operation(Dir.glob('git/*')) if want_to_install?(:git_configs, installation_mode)
+  file_operation(Dir.glob('irb/*')) if want_to_install?(:irb_pry_configs, installation_mode)
+  file_operation(Dir.glob('ruby/*')) if want_to_install?(:rubygems_config, installation_mode)
+  file_operation(Dir.glob('ctags/*')) if want_to_install?(:ctags_config, installation_mode)
+  file_operation(Dir.glob('vimify/*')) if want_to_install?(:vimify_command_line_tools, installation_mode)
+  file_operation(Dir.glob('{vim,vimrc}')) if want_to_install?(:vim_config, installation_mode)
+
+  if want_to_install?(:zsh_enhancements_and_prezto, installation_mode)
     install_prezto
   end
 
@@ -29,8 +49,18 @@ task :submodules do
   sh('git submodule update --init')
 end
 
+file @answers_file do
+  fail "#{@answers_file} already exists; please delete it first." if answers_file_ok?
+  write_skeleton_answers_file
+end
+desc "Create skeleton answers file that says 'yes' to everything"
+task :answers => @answers_file
+
+desc "Interactive install"
 task :default => 'install'
 
+desc "Unattended install, yes to everything, overwrite files where already existing"
+task :unattended_brutal => [:answers, :install]
 
 private
 def run(cmd)
@@ -54,9 +84,44 @@ def install_prezto
   run %{ mkdir -p $HOME/.zsh.prompts }
 end
 
-def want_to_install? (section)
-  puts "Would you like to install configuration files for: #{section}? [y]es, [n]o"
-  STDIN.gets.chomp == 'y'
+def answers_file_ok?
+  File.exists? @answers_file
+end
+
+def process_answers_file
+  unless answers_file_ok?
+    fail <<-EOS
+Must create valid YAML answers file to install unattended.
+Please run `rake unattended:answers` to create the skeleton at ./answers.yml, and then edit it.
+This can then be re-used.
+EOS
+  end
+  @answers = YAML.load_file @answers_file
+end
+
+def write_skeleton_answers_file
+  yaml = {
+    git_configs: 'y',
+    irb_pry_configs: 'y',
+    rubygems_config: 'y',
+    ctags_config: 'y',
+    vimify_command_line_tools: 'y',
+    vim_config: 'y',
+    zsh_enhancements_and_prezto: 'y'
+  }.to_yaml
+  File.open('answers.yml', 'w') do |content|
+    content.puts "# Valid answers are y or no for yes or no."
+    content.puts yaml
+  end
+end
+
+def want_to_install? (section, mode)
+  if mode == :interactive
+    puts "Would you like to install configuration files for: #{questions[:section]}? [y]es, [n]o"
+    answer = STDIN.gets.chomp == 'y'
+  else
+    answer = answers[section] == 'y'
+  end
 end
 
 def file_operation(files, method = :symlink)
@@ -78,7 +143,8 @@ def file_operation(files, method = :symlink)
       unless skip_all || overwrite_all || backup_all
         puts "File already exists: #{target}, what do you want to do? [s]kip, [S]kip all, [o]verwrite, [O]verwrite all, [b]ackup, [B]ackup all"
         case STDIN.gets.chomp
-        when 'o' then overwrite = true when 'b' then backup = true
+        when 'o' then overwrite = true
+        when 'b' then backup = true
         when 'O' then overwrite_all = true
         when 'B' then backup_all = true
         when 'S' then skip_all = true


### PR DESCRIPTION
This starts to fix #162.
- Introduce answers file for rake to read from, instead of STDIN,
  when it needs to know whether to install a feature or not.
- Add a rake task to generate a default answers file that says yes
  to all features, with a comment at the top regarding answer syntax.
- Branch execution so that if an answers file exists, we consider
  assume unattended installation.

TODO: Figure out how to do something similar for the overwrite/
backup prompts.  Ideas welcome.  Simplest is just to backup all
files, I guess, and let the user diff them if he wants.  Rationale
being that for an unattended install, there are either
a) probably no user customisations in the first place, since it'll
be a from bare-metal provisioning scenario
b) or specific pre-customised files to be dropped in over the top
anyway for site-specific consistency.
... at any rate, that's my scenario ;-)

@skwp This is a work-in-progress at the moment; wanted a bit of feedback before continuing.
