### PR TITLE
support rbenv version in skwp prompt

### DIFF
--- a/zsh/prezto-themes/prompt_skwp_setup
+++ b/zsh/prezto-themes/prompt_skwp_setup
@@ -15,11 +15,14 @@
 function rvm_info_for_prompt {
   if [[ -d ~/.rvm/ ]]; then
     ruby_version=$(~/.rvm/bin/rvm-prompt)
+    if [ -n "$ruby_version" ]; then
+      echo "[$ruby_version]"
+    fi
   elif [[ -d ~/.rbenv/ ]]; then
-    ruby_version=$(<~/.rbenv/version)
-  fi
-  if [ -n "$ruby_version" ]; then
-    echo "[$ruby_version]"
+    ruby_version=(${(s: :)$(rbenv version)})
+    if [ -n "$ruby_version" ]; then
+      echo "[${ruby_version[1]}]"
+    fi
   fi
 }
 


### PR DESCRIPTION
This change allows seeing the rbenv Ruby version in the right-side prompt when using the skwp theme.
