### PR TITLE
Added `vim/spell` to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vim/view
 *un~
 vim/.netrwhist
 vim/tmp
+vim/spell
 vim/after/.vimrc.after
 .netrwhist
 bin/subl


### PR DESCRIPTION
Add vim/spell/ to .gitignore to for users (like me) who use the vim spell checker.

Related #177
