### PR TITLE
change vim-jade submodule URL from git:// to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -352,7 +352,7 @@
   ignore = dirty
 [submodule "vim/bundle/digitaltoad-vim-jade"]
 	path = vim/bundle/digitaltoad-vim-jade
-	url = git://github.com/digitaltoad/vim-jade.git
+	url = https://github.com/digitaltoad/vim-jade.git
   ignore = dirty
 [submodule "vim/bundle/tpope-vim-ragtag"]
 	path = vim/bundle/tpope-vim-ragtag


### PR DESCRIPTION
The https:// version has less chance of causing a problem behind a firewall,
in which case the `rake install` and `rake update` commands do not work
correctly. A failure when updating/initializing submodules causes the
`git submodule` command to exit early before processing all submodules.
