### PR TITLE
Configure Macvim as the standard git mergetool

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -84,9 +84,15 @@
   svnl = svn log --oneline --show-commit
 [format]
   pretty = format:%C(blue)%ad%Creset %C(yellow)%h%C(green)%d%Creset %C(blue)%s %C(magenta) [%an]%Creset
+[mergetool]
+  prompt = false
+[mergetool "mvimdiff"]
+  cmd="mvim -c 'Gdiff' $MERGED"     # use fugitive.vim for 3-way merge
+  keepbackup=false
 [merge]
   summary = true
   verbosity = 1
+  tool = mvimdiff
 [apply]
   whitespace = nowarn
 [branch]


### PR DESCRIPTION
Why use something else than Macvim with fugitive.vim as a mergetool?
