### PR TITLE
Fixed vim alias.

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -32,8 +32,10 @@ alias ae='vi $yadr/zsh/aliases.zsh' #alias edit
 alias ar='source $yadr/zsh/aliases.zsh'  #alias reload
 
 # vim using
-if [ "$(command -v brew)" ]; then
-  alias vim=$(brew ls macvim | grep Contents/MacOS/Vim)
+mvim --version > /dev/null 2>&1
+MACVIM_INSTALLED=$?
+if [ $MACVIM_INSTALLED -eq 0 ]; then
+  alias vim="mvim -v"
 fi
 
 # vimrc editing


### PR DESCRIPTION
This fix solves the problem reported at #219
- Only set vim alias if MacVim is installed (using homebrew or not)
-  `mvim -v` uses vim from MacVim.app
