### PR TITLE
Aliases cleanup

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -5,7 +5,6 @@ yadr=$HOME/.yadr
 
 # YADR support
 alias yav='yadr vim-add-plugin'
-alias yuv='yadr update-plugins' #FIXME: backwards compatibility. Kill me after Jan 1, 2013
 alias yup='yadr update-plugins'
 alias yip='yadr init-plugins'
 


### PR DESCRIPTION
Remove some aliases, modify others.
- Remove `..` alias, as it is already done by zsh by default.
- Use `vim` instead of `vi` on aliases once `vi` opens vim that comes with the system.
- Remove the deprecated `yuv` alias.
