### PR TITLE
Skip homebrew install if it's already in the path

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,7 @@ def install_rvm_binstubs
 end
 
 def install_homebrew
-  brew_path = run("which brew")
+  run %{which brew}
   unless $?.success?
     puts "======================================================"
     puts "Installing Homebrew, the OSX package manager...If it's"


### PR DESCRIPTION
I'd like to skip the homebrew installation because I have it already installed and I don't want to mess my configuration.

This patch skips the installation process if brew is already in the path.
