### PR TITLE
Fix a bug that was causing rake to overwrite SHELL settings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,8 +146,12 @@ def install_prezto
   run %{ mkdir -p $HOME/.zsh.after }
   run %{ mkdir -p $HOME/.zsh.prompts }
 
-  puts "Setting zsh as your default shell"
-  run %{ chsh -s /bin/zsh }
+  if ENV[SHELL].include? 'zsh' then
+    puts "Zsh is already configured as your shell of choice. Restart your session to load the new settings"
+  else
+    puts "Setting zsh as your default shell"
+    run %{ chsh -s /bin/zsh }
+  end
 end
 
 def want_to_install? (section)


### PR DESCRIPTION
The prezto install procedure now checks to make sure the user
doesn't have an alternative version of zsh installed before changing
the current shell preference with "chsh".
This may be the case when an user is already using zsh but on a
different version from the one shipped with OS X

Fixes #264
