### PR TITLE
Fix a bug that's causing the installer to overwrite backup files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -169,7 +169,7 @@ def file_operation(files, method = :symlink)
     puts "Source: #{source}"
     puts "Target: #{target}"
 
-    if File.exists?(target) || File.symlink?(target)
+    if File.exists?(target) && (!File.symlink?(target) || (File.symlink?(target) && File.readlink(target) != source))
       puts "[Overwriting] #{target}...leaving original at #{target}.backup..."
       run %{ mv "$HOME/.#{file}" "$HOME/.#{file}.backup" }
     end


### PR DESCRIPTION
When rake install/update is run for the second time, any .backup
file created by the first run it's going to be overwritten by
the new symlink even if the current file is the same as the one
we are going to write.

The rakefile now checks if the symlink we are going to create
points to the same target as the one already there and if that's
the case, doesn't overwrite any backup.
