### PR TITLE
"uninitialized constant SHELL" in zsh install step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -146,7 +146,7 @@ def install_prezto
   run %{ mkdir -p $HOME/.zsh.after }
   run %{ mkdir -p $HOME/.zsh.prompts }
 
-  if ENV[SHELL].include? 'zsh' then
+  if ENV["SHELL"].include? 'zsh' then
     puts "Zsh is already configured as your shell of choice. Restart your session to load the new settings"
   else
     puts "Setting zsh as your default shell"


### PR DESCRIPTION
fresh install:

```
** Execute install_prezto

Installing Prezto (ZSH Enhancements)...

Overriding prezto ~/.zpreztorc with YADR's zpreztorc to enable additional modules...
[Running]  ln -nfs "$HOME/.yadr/zsh/prezto-override/zpreztorc" "${ZDOTDIR:-$HOME}/.zpreztorc"

Creating directories for your customizations
[Running]  mkdir -p $HOME/.zsh.before
[Running]  mkdir -p $HOME/.zsh.after
[Running]  mkdir -p $HOME/.zsh.prompts
rake aborted!
uninitialized constant SHELL
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rake.rb:2503:in `const_missing'
/Users/chadkouse/.yadr/Rakefile:149:in `install_prezto'
/Users/chadkouse/.yadr/Rakefile:34
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rake.rb:636:in `call'
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rake.rb:636:in `execute'
```
