### PR TITLE
Improved semicolon insertion

### DIFF
--- a/vim/plugin/settings/yadr-append-semicolon.vim
+++ b/vim/plugin/settings/yadr-append-semicolon.vim
@@ -1,0 +1,13 @@
+" If there isn't one, append a semi colon to the end of the current line.
+function! s:appendSemiColon()
+  if getline('.') !~ ';$'
+    let original_cursor_position = getpos('.')
+    exec("s/$/;/")
+    call setpos('.', original_cursor_position)
+  endif
+endfunction
+
+" For programming languages using a semi colon at the end of statement.
+autocmd FileType c,cpp,css,java,javascript,perl,php,jade nmap <silent> ;; :call <SID>appendSemiColon()<CR>
+autocmd FileType c,cpp,css,java,javascript,perl,php,jade inoremap <silent> ;; <ESC>:call <SID>appendSemiColon()<CR>a
+

--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -65,9 +65,6 @@ vmap ,{ c{<C-R>"}<ESC>
 " gary bernhardt's hashrocket
 imap <c-l> <space>=><space>
 
-" Semicolon at end of line by typing ;;
-inoremap ;; <C-o>A;<esc>
-
 " Change inside various enclosures with Cmd-" and Cmd-'
 " The f makes it find the enclosure so you don't have
 " to be standing inside it


### PR DESCRIPTION
Improved semicolon insertion via the shortcut `;;`:

**Improvements:**
- Now also works for normal mode instead of only insert mode.
- Doesn't leave insert mode after inserting the `;`
- Remembers the current cursor position instead of just leaving it at the end of the line regardless of where you were.
- Doesn't insert a `;` if there is one present already
