### PR TITLE
Change installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
     # Yet Another Dotfile Repo v1.1
     # Now with Prezto and Vundle!
 
-    git clone https://github.com/skwp/dotfiles ~/.yadr
-    cd ~/.yadr && rake install
+    sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`"
 
 **Always be sure to run `rake update` after pulling to ensure plugins are updated**
 
@@ -45,12 +44,14 @@ Installation is automated via `rake` and the `yadr` command. To get
 started please run:
 
 ```bash
-git clone https://github.com/skwp/dotfiles ~/.yadr
-cd ~/.yadr && rake install
+sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`"
 ```
 
 **Note:** YADR will automatically install all of its subcomponents. If you want to be asked
-about each one, use `ASK=true rake install`
+about each one, use:
+```bash
+sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`" -s ask
+```
 
 # Additional Installation
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ ! -d "$HOME/.yadr" ]; then
+    echo "Installing YADR for the first time"
+    git clone https://github.com/skwp/dotfiles.git "$HOME/.yadr"
+    cd "$HOME/.yadr"
+    [ "$1" == "ask" ] && export ASK="true"
+    rake install
+else
+    echo "YADR is already installed"
+fi


### PR DESCRIPTION
Instead of asking the user to clone the repo and running rake
install, there's is now an easy .sh script that can be downloaded
and invoked in a single line.

The script takes a parameter "ask" if the use prefers to control
which modules of yadr are installed.

**NOTE**: The script mentioned on the updated README.md will only work once install.sh is merged into master.
