### PR TITLE
Change indent/unindent behaviour in visual mode

### DIFF
--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -130,6 +130,10 @@ nnoremap ,gcf :call GitGrep(expand("%:t:r"))<CR>
 nnoremap <silent> ,z :bp<CR>
 nnoremap <silent> ,x :bn<CR>
 
+" Reselect visual block after indent/outdent
+vnoremap < <gv
+vnoremap > >gv
+
 " ==============================
 " Window/Tab/Split Manipulation
 " ==============================


### PR DESCRIPTION
After indenting/unindenting the selected lines of code, vim
deselects forcing the user to reapply the selection in order to
indent multiple times.

This remap fixes the problem.
