### PR TITLE
Add .vundles.local to allow per-installation plugin customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vim/.netrwhist
 vim/tmp
 vim/spell
 vim/after/.vimrc.after
+vim/.vundles.local
 vim/bundle
 .netrwhist
 bin/subl

--- a/bin/yadr/vundle.rb
+++ b/bin/yadr/vundle.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 
 module Vundle
-  @vundles_path = File.expand_path File.join('~', '.vim', 'vundles.vim')
+  @vundles_path = File.expand_path File.join(ENV['HOME'], '.vim', '.vundles.local')
   def self.add_plugin_to_vundle(plugin_repo)
     return if contains_vundle? plugin_repo
 

--- a/vim/vundles.vim
+++ b/vim/vundles.vim
@@ -102,5 +102,13 @@ Bundle "airblade/vim-gitgutter.git"
 Bundle "bogado/file-line.git"
 Bundle "tpope/vim-rvm.git"
 Bundle "nelstrom/vim-visual-star-search"
+
+" Customization
+" The plugins listed in ~/.vim/.vundles.local will be added here to
+" allow the user to add vim plugins to yadr without the need for a fork.
+if filereadable(expand("~/.yadr/vim/.vundles.local"))
+  source ~/.yadr/vim/.vundles.local
+endif
+
 "Filetype plugin indent on is required by vundle
 filetype plugin indent on


### PR DESCRIPTION
Adding and removing vim plugins is now done by adding and removing
from ~/.vim/.vundles.local. This file is sourced at the end of
vundles.vim

Fixes #275
