### PR TITLE
Making 's' and 'v' respond instantly

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,6 @@ If you omit the key combo, you'll get a list of all the maps. You can do the sam
 
 #### Splits
 
- * `vv` - vertical split (`Ctrl-w,v`)
- * `ss` - horizontal split (`Ctrl-w,s`)
  * `,qo` - open quickfix window (this is where output from GitGrep goes)
  * `,qc` - close quickfix
 
@@ -317,8 +315,8 @@ If you omit the key combo, you'll get a list of all the maps. You can do the sam
  * `,ow` - overwrite a word with whatever is in your yank buffer - you can be anywhere on the word. saves having to visually select it
  * `,ocf` - open changed files (stolen from @garybernhardt). open all files with git changes in splits
  * `,w` - strip trailing whitespaces
- * `sj` - split a line such as a hash {:foo => {:bar => :baz}} into a multiline hash (j = down)
- * `sk` - unsplit a link (k = up)
+ * `,sj` - split a line such as a hash {:foo => {:bar => :baz}} into a multiline hash (j = down)
+ * `,sk` - unsplit a link (k = up)
  * `,he` - Html Escape
  * `,hu` - Html Unescape
  * `,hp` - Html Preview (open in Safari)

--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -156,12 +156,6 @@ map <silent> <D-7> :tabn 7<cr>
 map <silent> <D-8> :tabn 8<cr>
 map <silent> <D-9> :tabn 9<cr>
 
-" Create window splits easier. The default
-" way is Ctrl-w,v and Ctrl-w,s. I remap
-" this to vv and ss
-nnoremap <silent> vv <C-w>v
-nnoremap <silent> ss <C-w>s
-
 " Resize windows with arrow keys
 nnoremap <D-Up> <C-w>+
 nnoremap <D-Down> <C-w>-
@@ -217,8 +211,8 @@ vmap <D-A> :Tabularize /
 " ============================
 " SplitJoin plugin
 " ============================
-nmap sj :SplitjoinSplit<cr>
-nmap sk :SplitjoinJoin<cr>
+nmap ,sj :SplitjoinSplit<cr>
+nmap ,sk :SplitjoinJoin<cr>
 
 " ============================
 " vim-ruby-conque


### PR DESCRIPTION
I think it's good to keep vim's default behaviour for the basics / most used things... It's a way of minimizing the amount os stuff we have to (re)memorize when switching normal VIM to YADR's vim.

And, personally, I was feeling a drag when trying to use the old `s`. I was annoyed when I tried to `ss` for substituting the char `s` under the cursor and continuing typing :) when all of a sudden a split opened :smile:

The same goes to `v` (visual char).

So for the split joins I put a comma before the mappings. Still easy to remember and mnemonic.

And for the window shortcuts I had to remove them for not being able to find a better non-conflicting map. (`,vv` and `,ss` already do something else). And, to be honest, most of the times I open a vertical or horizontal split it is via Ctrl-P or NERD tree, not via an already opened buffer... So I wouldn't mind, in these more rare cases, doing the old `<C-w> s` for that...
