### PR TITLE
Externalizing and improving search configuration

### DIFF
--- a/vim/plugin/settings/yadr-search.vim
+++ b/vim/plugin/settings/yadr-search.vim
@@ -1,0 +1,8 @@
+" ================ Search Settings  =================
+
+set incsearch       " Find the next match as we type the search
+set hlsearch        " Hilight searches by default
+set viminfo='100,f1 " Save up to 100 marks, enable capital marks
+set ignorecase      " Ignore case when searching...
+set smartcase       " ...unless we type a capital
+

--- a/vimrc
+++ b/vimrc
@@ -40,12 +40,6 @@ if filereadable(expand("~/.vim/vundles.vim"))
   source ~/.vim/vundles.vim
 endif
 
-" ================ Search Settings  =================
-
-set incsearch        "Find the next match as we type the search
-set hlsearch         "Hilight searches by default
-set viminfo='100,f1  "Save up to 100 marks, enable capital marks
-
 " ================ Turn Off Swap Files ==============
 
 set noswapfile


### PR DESCRIPTION
I remember reading somewhere here that you wanted to start modularizing the configs sections on vimrc, so I just did that with the search related ones, and added a new config to make searching better (imo, of course :smile: ). 

Now:
- if you wanna search for `doStuff` you can search for `dos` and have it found
- if you wanna search for `doStuff` but not wasting the time with occurences like `dos is crap` then you can type `doS` and only match the exact occurences...

Quite handy imo.
Thanks
