### PR TITLE
Fix: [Zsh] load ssh-agent module

### DIFF
--- a/zsh/prezto-override/zpreztorc
+++ b/zsh/prezto-override/zpreztorc
@@ -39,6 +39,7 @@ zstyle ':prezto:load' pmodule \
   'ruby' \
   'syntax-highlighting' \
   'history-substring-search' \
+  'ssh-agent' \
   'prompt'
 
 #


### PR DESCRIPTION
You have 

```
zstyle ':prezto:module:ssh-agent' forwarding 'yes'
```

uncommented, but don't load `ssh-agent` module. I fixed it.
