### PR TITLE
Small fix documentation for CtrlP vim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ If you omit the key combo, you'll get a list of all the maps. You can do the sam
  * EasyMotion - hit ,<esc> (forward) or ,<Shift-Esc> (back) and watch the magic happen. Just type the letters and jump directly to your target - in the provided vimrc the keys are optimized for home row mostly. Using @skwp modified EasyMotion which uses vimperator-style two character targets.
  * LustyJuggler/Explorer - hit B, type buf name to match a buffer, or type S and use the home row keys to select a buffer
  * TagBar - hit ,T to see a list of methods in a class (uses ctags)
- * CtrlP - Ctrl-p or ,t to find a file
+ * CtrlP - ,t to find a file
  * Visual-star-search - make the * (star) search in visual mode behave like expected: searching for the whole selection instead of just the word under the cursor.
 
 #### Git


### PR DESCRIPTION
Ctrl-p shortcut is actually used by yankring plugin
(cherry picked from commit 26400827300686ad5f3d4daba0f1b841e12d474a)
