### PR TITLE
Fix: make vim command be os-specific, readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ We include the `ghi` command. Try `ghi list` and have fun managing issues from c
 
 ### Ruby Debugger
 
-This gem is optonal and not included. It's used to give you visual IDE-style debugging within vim, combined
-with the vim-ruby-debugger plugin. To install:
+This plugin is optional and not included. It's used to give you visual IDE-style debugging within vim, combined
+with the debugger-xml gem. To install:
 
 ```bash
-gem install ruby-debug-ide
+gem install debugger-xml
 ```
 
 ### ZSH

--- a/vim/plugin/settings/vim-ruby-debugger.vim
+++ b/vim/plugin/settings/vim-ruby-debugger.vim
@@ -2,7 +2,10 @@
 "<leader>b
 let g:ruby_debugger_no_maps=1
 
-let g:ruby_debugger_progname='mvim'
+let os=substitute(system('uname'), '\n', '', '')
+if os == 'Darwin' || os == 'Mac'
+  let g:ruby_debugger_progname='mvim'
+endif
 
 "Make our own maps
 noremap <leader>db  :call ruby_debugger#load_debugger() <bar> call g:RubyDebugger.toggle_breakpoint()<CR>


### PR DESCRIPTION
I've made `ruby_debugger_progname` to be os-specific and have fixed out-of-date im-ruby-debugger readme section.
