### PR TITLE
Disable Expose ( Mission Control ) Animations

### DIFF
--- a/osx
+++ b/osx
@@ -27,6 +27,9 @@ defaults write NSGlobalDomain NSTextShowsControlCharacters -bool true
 # Disable opening and closing window animations
 defaults write NSGlobalDomain NSAutomaticWindowAnimationsEnabled -bool false
 
+# Disable Mission Control Animations
+defaults write com.apple.dock expose-animation-duration -int 0
+
 # Increase window resize speed for Cocoa applications
 defaults write NSGlobalDomain NSWindowResizeTime -float 0.001
 


### PR DESCRIPTION
They suck when using multiple displays, no need to have them.
