### PR TITLE
Retain visual selection while indenting

### DIFF
--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -15,6 +15,10 @@ nnoremap ,ow "_diwhp
 "make Y consistent with C and D
 nnoremap Y y$
 
+" retain visual mode while indenting
+vnoremap > >gv
+vnoremap < <gv
+
 " ========================================
 " RSI Prevention - keyboard remaps
 " ========================================


### PR DESCRIPTION
This is one of the first things I usually add to my `vimrc`(before I found yadr of course). Currently, if you select a block and hit `>`. The block gets indented but you loose the visual selection and you have to hit `gv` to get it back. This commit should fix that.
