### PR TITLE
Removes Swipe back/forth feature for Chrome

### DIFF
--- a/osx
+++ b/osx
@@ -234,6 +234,9 @@ defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
 # Disable local Time Machine backups
 # hash tmutil &> /dev/null && sudo tmutil disablelocal
 
+# Disable Swipe controls for Google Chrome
+defaults write com.google.Chrome.plist AppleEnableSwipeNavigateWithScrolls -bool FALSE
+
 # # Remove Dropbox’s green checkmark icons in Finder
 # file=/Applications/Dropbox.app/Contents/Resources/check.icns
 # [ -e "$file" ] && mv -f "$file" "$file.bak"


### PR DESCRIPTION
Swiping on Chrome my accident is a pain when using the inspector, this command will disable it only for Google Chrome **only**.
