### PR TITLE
Add multiple selection

### DIFF
--- a/vim/plugin/settings/vim-multiple-cursors.vim
+++ b/vim/plugin/settings/vim-multiple-cursors.vim
@@ -1,0 +1,12 @@
+" Turn off default key mappings
+let g:multi_cursor_use_default_mapping=0
+
+" Switch to multicursor mode with Apple-*
+let g:multi_cursor_start_key='<D-*>'
+
+" Ctrl-n, Ctrl-p, Ctrl-x, and <Esc> are mapped in the special multicursor
+" mode once you've added at least one virtual cursor to the buffer
+let g:multi_cursor_next_key='<C-n>'
+let g:multi_cursor_prev_key='<C-p>'
+let g:multi_cursor_skip_key='<C-x>'
+let g:multi_cursor_quit_key='<Esc>'

--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -191,10 +191,6 @@ nmap <silent> ,vr :so %<CR>
 " Type ,hl to toggle highlighting on/off, and show current value.
 noremap ,hl :set hlsearch! hlsearch?<CR>
 
-" Apple-* Highlight all occurrences of current word (like '*' but without moving)
-" http://vim.wikia.com/wiki/Highlight_all_search_pattern_matches
-nnoremap <D-*> :let @/='\<<C-R>=expand("<cword>")<CR>\>'<CR>:set hls<CR>
-
 " These are very similar keys. Typing 'a will jump to the line in the current
 " file marked with ma. However, `a will jump to the line and column marked
 " with ma.  It’s more useful in any case I can imagine, but it’s located way

--- a/vim/vundles.vim
+++ b/vim/vundles.vim
@@ -71,6 +71,7 @@ Bundle "tpope/vim-bundler"
 Bundle "vim-scripts/IndexedSearch"
 Bundle "vim-scripts/camelcasemotion.git"
 Bundle "vim-scripts/matchit.zip.git"
+Bundle "terryma/vim-multiple-cursors"
 
 " General vim improvements
 Bundle "MarcWeber/vim-addon-mw-utils.git"


### PR DESCRIPTION
This plugin is bringing Sublime Text's fantastic multiple selection editing possibilities to VIM.

Hitting `Ctrl-n` selects the word under your cursor and hitting it again selects the next occurrence of the word. From there you can edit all selections at once. Super handy!

Shall I add instructions to the README and the gh–pages?
