### PR TITLE
Fix: dirty worktree after running 'rake install' [Fix #311]

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ end
 
 task :submodule_init do
   unless ENV["SKIP_SUBMODULES"]
-    run %{ git submodule update --init --recursive }
+    run %{ git submodule init }
   end
 end
 
@@ -62,7 +62,7 @@ task :submodules do
 
     run %{
       cd $HOME/.yadr
-      git submodule foreach 'git fetch origin; git checkout master; git reset --hard origin/master; git submodule update --recursive; git clean -df'
+      git submodule update --recursive
       git clean -df
     }
     puts


### PR DESCRIPTION
'rake install' was getting the latest version of **prezto** instead of the version in dotfiles.
