### PR TITLE
Making camel case motions work consistenly when dealing with text objects

### DIFF
--- a/vim/plugin/settings/camelcasemotion.vim
+++ b/vim/plugin/settings/camelcasemotion.vim
@@ -5,3 +5,10 @@ map E <Plug>CamelCaseMotion_e
 sunmap W
 sunmap B
 sunmap E
+
+omap <silent> iW <Plug>CamelCaseMotion_iw
+xmap <silent> iW <Plug>CamelCaseMotion_iw
+omap <silent> iB <Plug>CamelCaseMotion_ib
+xmap <silent> iB <Plug>CamelCaseMotion_ib
+omap <silent> iE <Plug>CamelCaseMotion_ie
+xmap <silent> iE <Plug>CamelCaseMotion_ie


### PR DESCRIPTION
So now we can use `cW` to change "Camel" in "CamelCaseMotion" accordingly
