### PR TITLE
[Fix #311] zsh/presto gets "modified" after clean install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ task :submodules do
 
     run %{
       cd $HOME/.yadr
-      git submodule foreach 'git fetch origin; git checkout master; git reset --hard origin/master; git submodule update --recursive; git clean -df'
+      git submodule update --recursive
       git clean -df
     }
     puts


### PR DESCRIPTION
Changes the `:submodules` rake task to avoid downloading prezto upstream instead of yadr version.
