### PR TITLE
Remove duplicate plugins from vundles.vim

### DIFF
--- a/vim/vundles.vim
+++ b/vim/vundles.vim
@@ -120,11 +120,7 @@ Bundle "chrisbra/color_highlight.git"
 Bundle "skwp/vim-colors-solarized"
 Bundle "skwp/vim-powerline.git"
 Bundle "vim-scripts/TagHighlight.git"
-Bundle "itspriddle/vim-jquery.git"
-Bundle "slim-template/vim-slim.git"
 Bundle "bogado/file-line.git"
-Bundle "tpope/vim-rvm.git"
-Bundle "nelstrom/vim-visual-star-search"
 
 " Customization
 " The plugins listed in ~/.vim/.vundles.local will be added here to


### PR DESCRIPTION
I noticed these duplicates while cleaning up my `vundles.vim`. 
