### PR TITLE
Fixing Y behaviour

### DIFF
--- a/vim/plugin/settings/yadr-keymap.vim
+++ b/vim/plugin/settings/yadr-keymap.vim
@@ -14,6 +14,9 @@ nnoremap ,ow "_diwhp
 
 "make Y consistent with C and D
 nnoremap Y y$
+function! YRRunAfterMaps()
+  nnoremap Y   :<C-U>YRYankCount 'y$'<CR>
+endfunction
 
 " ========================================
 " RSI Prevention - keyboard remaps


### PR DESCRIPTION
The line in `yadr-keymap.vim`:

```
"make Y consistent with C and D
nnoremap Y y$
```

Was actually not working because YankRing replaces on commands that yanks something.

So I did the change as suggest in yankring's doc:

```
When capital Y is pressed, the YankRing will execute 'Y' and capture the
output from Vim.  But there are cases where you do not want the default
behaviour of Vim, since you have customized some of these maps.

In this case, I usually map Y to be |y$|, which makes it consistent with 
the |D| and |C| operators.  The way yankring_n_keys works does not allow
me to customize this behaviour.  Since many people may like to customize
the behaviour of these maps the YankRing will check to see if a
function called YRRunAfterMaps() exists.  If it does, it will call 
this function after it has created the maps.  So in my case, I created
the following function in my |vimrc|: >
    function! YRRunAfterMaps()
        nnoremap Y   :<C-U>YRYankCount 'y$'<CR>
    endfunction
<
```
