### PR TITLE
Updates RubyGem sources

### DIFF
--- a/ruby/gemrc
+++ b/ruby/gemrc
@@ -1,8 +1,7 @@
 ---
 :update_sources: true
 :sources:
-- http://gems.rubyforge.org/
-- http://gems.github.com
+- http://rubygems.org
 :benchmark: false
 :bulk_threshold: 1000
 :backtrace: false


### PR DESCRIPTION
`gems.rubyforge.org` and `gems.github.com` have been replaced with `rubygems.org` as RubyGems sources.
