### PR TITLE
Remove redundant recommended OSX tool 'autojump'  from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,6 @@ These hacks are Lion-centric. May not work for other OS'es. My favorite mods inc
  * NValt - Notational Velocity alternative fork - http://brettterpstra.com/project/nvalt/ - syncs with SimpleNote
  * Vimium for Chrome - vim style browsing. The `f` to type the two char alias of any link is worth it.
  * QuickCursor - gives you Apple-Shift-E to edit any OSX text field in vim.
- * brew install autojump - will track your commonly used directories and let you jump there. With the zsh plugin you can just type `j [dirspec]`, a few letters of the dir you want to go to.
 
 
 ### Credits


### PR DESCRIPTION
autojump 'j' functionality is matched/replaced by fasd 'z' command (installed and enabled as a prezto submodule by default). Instead of typing `j [dirspec]`, you simply type `z [dirspec]`.
