### PR TITLE
Allow users to overwrite the tmux configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ It is recommended to use this file to set your user info. Alternately, you can s
 
 A .gemrc is included. Never again type `gem install whatever --no-ri --no-rdoc`. `--no-ri --no-rdoc` is done by default.
 
+### Tmux configuration
+
+`tmux.conf` provides some sane defaults for tmux on Mac OS, a powerful status bar and vim keybindings.
+You can customize the configuration in `~/.tmux.conf.user`.
+
 ### Vimization of everything
 
 The provided inputrc and editrc will turn your various command line tools like mysql and irb into vim prompts. There's

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -4,7 +4,7 @@ set -g bell-action any
 # Default termtype. If the rcfile sets $TERM, that overrides this value.
 set -g default-terminal screen-256color
 # set -g default-terminal "screen-256color"
-#
+
 set-option -g default-command "reattach-to-user-namespace -l $SHELL -l"
 
 # Keep your finger on ctrl, or don't
@@ -26,10 +26,10 @@ bind-key L resize-pane -R
 # Use vi keybindings for tmux commandline input.
 # Note that to get command mode you need to hit ESC twice...
 set -g status-keys vi
- 
+
 # Use vi keybindings in copy and choice modes
 setw -g mode-keys vi
-# 
+
 # easily toggle synchronization (mnemonic: e is for echo)
 # sends input to all panes in a given window.
 bind e setw synchronize-panes on
@@ -72,4 +72,6 @@ bind C-a last-window
 
 # Bigger history
 set -g history-limit 10000
-#
+
+# Local config
+if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'


### PR DESCRIPTION
Just as it is possible for the users to overwrite or extend the git configuration via the `gitconfig.user` file, this allows the users to do the same for tmux configuration. 
