### PR TITLE
Add fortune to packages installed via homebrew

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -150,7 +150,7 @@ def install_homebrew
   puts "======================================================"
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
-  run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher}
+  run %{brew install zsh ctags fortune git hub tmux reattach-to-user-namespace the_silver_searcher}
   puts
   puts
 end


### PR DESCRIPTION
zlogin (from prezto) attempts to call fortune on login, but the package is not installed by default. This patch fixes that.

```
# Print a random, hopefully interesting, adage.
if (( $+commands[fortune] )); then
  fortune -a
  print
fi
```
