### PR TITLE
Enable tmux to send-prefix using C-a a

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -61,6 +61,7 @@ set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg
 # Screen like binding
 unbind C-b
 set -g prefix C-a
+bind a send-prefix
 
 # No escape time for vi mode
 set -sg escape-time 0


### PR DESCRIPTION
It's useful when you have a tmux session into another tmux session (ie. via ssh). This is the behaviour included in the screen-keys.conf configuration file which is packaged with tmux.
