### PR TITLE
Remove setting 256 colors for solarized on terminal vim

### DIFF
--- a/vim/settings/solarized.vim
+++ b/vim/settings/solarized.vim
@@ -1,7 +1,7 @@
-if !has("gui_macvim")
-  set t_Co=256
-  let g:solarized_termcolors=256
-endif
+" if !has("gui_macvim")
+"   set t_Co=256
+"   let g:solarized_termcolors=256
+" endif
 
 hi! link txtBold Identifier
 hi! link zshVariableDef Identifier


### PR DESCRIPTION
these settings confuse the solarized colors in terminal vim, which is for example always used for git commits. without them the latest terminal vim has the perfect solarized experience. 

without those settings:
![after](https://f.cloud.github.com/assets/563961/1647389/9aa8abe4-593e-11e3-8cad-eb4077273a3e.png)

with those settings:
![before](https://f.cloud.github.com/assets/563961/1647390/9ac18812-593e-11e3-8218-3954f47fcf5e.png)

so the question is: why has it been added?
