### PR TITLE
Remove setting 256 colors for solarized on terminal vim

### DIFF
--- a/vim/settings/solarized.vim
+++ b/vim/settings/solarized.vim
@@ -1,6 +1,5 @@
 if !has("gui_macvim")
   set t_Co=256
-  let g:solarized_termcolors=256
 endif
 
 hi! link txtBold Identifier


### PR DESCRIPTION
Since the problem with b19e2311abf3e65a79ef5e73efe18cc84a57e00f seems to be resolved, I am bringing the commit back.
