### PR TITLE
Use ag as ctrlp's search command

### DIFF
--- a/vim/settings/ctrlp.vim
+++ b/vim/settings/ctrlp.vim
@@ -1,5 +1,10 @@
-let g:ctrlp_custom_ignore = '\.git$\|\.hg$\|\.svn$'
-let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files . --cached --exclude-standard --others']
+if executable('ag')
+  " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
+  let g:ctrlp_user_command = 'ag %s --files-with-matches -g "" --ignore "\.git$\|\.hg$\|\.svn$"'
+
+  " ag is fast enough that CtrlP doesn't need to cache
+  let g:ctrlp_use_caching = 0
+endif
 
 " Default to filename searches - so that appctrl will find application
 " controller


### PR DESCRIPTION
With this setting ctrlp is behaving as before, as far as i can tell and have tested it, but it needs no caching as ag is fast enough to do without and it respects exclusions from `.gitignore`. Brazenly stolen from http://robots.thoughtbot.com/faster-grepping-in-vim/
Any thoughts? Does this work as expected for you?
