### PR TITLE
Load correct fonts under GTK

### DIFF
--- a/vim/settings/yadr-appearance.vim
+++ b/vim/settings/yadr-appearance.vim
@@ -16,7 +16,11 @@ if has("gui_running")
   set lines=60
   set columns=190
 
-  set guifont=Inconsolata\ XL:h17,Inconsolata:h20,Monaco:h17
+  if has("gui_gtk2")
+    set guifont=Inconsolata\ XL\ 12,Inconsolata\ 15,Monaco\ 12
+  else
+    set guifont=Inconsolata\ XL:h17,Inconsolata:h20,Monaco:h17
+  end
 else
   "dont load csapprox if we no gui support - silences an annoying warning
   let g:CSApprox_loaded = 1


### PR DESCRIPTION
Hi,

I've just migrated to your awsome project and figgured out that the fonts looks really ugly under Linux. I've figgured out, that gvim is not actually loading the propper fonts. You need to use different names / syntax under different GUI environments...

  Antonin
