### PR TITLE
Fix for the warning the syntastic throws on startup

### DIFF
--- a/vim/settings/syntastic.vim
+++ b/vim/settings/syntastic.vim
@@ -5,4 +5,4 @@ let g:syntastic_auto_jump=0
 "show the error list automatically
 let g:syntastic_auto_loc_list=1
 "don't care about warnings
-let g:syntastic_quiet_warnings=0
+let g:syntastic_quiet_messages = {'level': 'warnings'}


### PR DESCRIPTION
I installed this repo today and get a warning each time vim starts due to a
change in the syntax in the syntastic configuration.
