### PR TITLE
Fix syntastic deprecation

### DIFF
--- a/vim/settings/syntastic.vim
+++ b/vim/settings/syntastic.vim
@@ -5,4 +5,4 @@ let g:syntastic_auto_jump=0
 "show the error list automatically
 let g:syntastic_auto_loc_list=1
 "don't care about warnings
-let g:syntastic_quiet_warnings=0
+let g:syntastic_quiet_messages = {'level': 'warnings'}


### PR DESCRIPTION
Fixes the deprecation message: "syntastic: warning: variable g:syntastic_quiet_warnings is deprecated, please use let g:syntastic_quiet_messages = {'level': 'warnings'} instead" by doing what is told.

Upon a fresh clone I got this message each time I started vim (ubuntu 13.10, fedora 19, debian 6).
