### PR TITLE
Add bundle parallel config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -120,10 +120,6 @@ def run(cmd)
 end
 
 def number_of_cores
-  puts "======================================================"
-  puts "Calculating number of cores"
-  puts "======================================================"
-
   if RUBY_PLATFORM.downcase.include?("darwin")
     cores = run %{ sysctl -n hw.ncpu }
   else


### PR DESCRIPTION
Runs bundle config to allow for faster gem installation. Based off of thoughtbot's laptop script. Here's a relevant [blog post](http://robots.thoughtbot.com/parallel-gem-installing-using-bundler) about bundle's parallel installation.
