### PR TITLE
Fixed wrong setup for easyvim

### DIFF
--- a/vim/settings/easymotion.vim
+++ b/vim/settings/easymotion.vim
@@ -9,13 +9,9 @@ call EasyMotion#InitOptions({
 \ , 'do_mapping'      : 1
 \ , 'grouping'        : 1
 \
-\ , 'hl_group_target' : 'Question'
-\ , 'hl_group_shade'  : 'EasyMotionShade'
+\ , 'hl_group_target' : 'ErrorMsg'
+\ , 'hl_group_shade'  : 'Comment'
 \ })
-
-" Make EasyMotion more yellow, less red
-hi clear EasyMotionTarget
-hi! EasyMotionTarget guifg=yellow
 
 nmap ,<ESC> ,,w
 nmap ,<S-ESC> ,,b


### PR DESCRIPTION
I had a lot of trouble getting easymotion to highlight well with the Solarized dark theme in iTerm. I figured out the reason it wasn't working.

The two settings `hl_group_target` and `hl_group_shade` are used to set your easymotion highlight groups.

`ErrorMsg` and `Comment` are [usually preferred](https://github.com/Lokaltog/vim-easymotion/blob/master/doc/easymotion.txt#L1000). They used to default to `EasyMotionTarget` and `EasyMotionShade`( in which case those groups would have to be defined later).

The lines I deleted are kind of useless. Not sure why `hl_group_target` was set to `Question` before. But, since `hl_group_target` was set to the `Question` highlight group, it would never have looked for the `EasyMotionTarget` group. So making it yellow was unnecessary in the first place.
