### PR TITLE
change string comparison

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ if [ ! -d "$HOME/.yadr" ]; then
     echo "Installing YADR for the first time"
     git clone https://github.com/skwp/dotfiles.git "$HOME/.yadr"
     cd "$HOME/.yadr"
-    [ "$1" == "ask" ] && export ASK="true"
+    [ "$1" = "ask" ] && export ASK="true"
     rake install
 else
     echo "YADR is already installed"


### PR DESCRIPTION
Hi,
When I try to install YADR on Ubuntu 12.10 LTS I get this error:

``` sh
sh: 7: [: unexpected operator
```

I think the standard string comparison operator is `=` and not `==`.
This fixes the error for me.
