### PR TITLE
Easymotion: expand navigation keys

### DIFF
--- a/vim/settings/easymotion.vim
+++ b/vim/settings/easymotion.vim
@@ -1,8 +1,5 @@
-" Use all letters and semicolon as navigation keys, as they are all in
-" close proximity to the home row and therefore easy to type.
 call EasyMotion#InitOptions({
 \   'leader_key'      : '<Leader><Leader>'
-\ , 'keys'            : 'asdghklqwertyuiopzxcvbnmfj;'
 \ , 'do_shade'        : 1
 \ , 'do_mapping'      : 1
 \ , 'grouping'        : 1


### PR DESCRIPTION
One thing I never really understood was the rationale behind the keys setting on line 7. The comment says it only uses the left home row, which isn't the case: J, K, O, and N are all on the right. Some home row keys, like L, aren't included, while other non-home row keys are like E and N. So, I'm not quite sure why this subset of keys are faster to type than say all the letters and basic punctuation (semicolon, comma, period), which are at-most distance 1 from home row.

Instead, use letters + semicolon as navigation keys, since they are all easily
accessible (easymotion default).
