### PR TITLE
Fix for iTerm themes install on Mavericks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -346,6 +346,7 @@ def apply_theme_to_iterm_profile_idx(index, color_scheme_path)
   values.flatten.each { |entry| run %{ /usr/libexec/PlistBuddy -c "Delete :'New Bookmarks':#{index}:'#{entry}'" ~/Library/Preferences/com.googlecode.iterm2.plist } }
 
   run %{ /usr/libexec/PlistBuddy -c "Merge '#{color_scheme_path}' :'New Bookmarks':#{index}" ~/Library/Preferences/com.googlecode.iterm2.plist }
+  run %{ defaults read com.googlecode.iterm2 }
 end
 
 def success_msg(action)


### PR DESCRIPTION
Mavericks cache preferences and overwrites defaults from cache, not
installing it properly. Reading it after install updates the cache with
new values.

http://hints.macworld.com/article.php?story=20130908042828630
