### PR TITLE
Fix in vim settings

### DIFF
--- a/vim/settings/ctrlp.vim
+++ b/vim/settings/ctrlp.vim
@@ -1,4 +1,6 @@
-unlet g:ctrlp_user_command
+if exists("g:ctrlp_user_command")
+  unlet g:ctrlp_user_command
+endif
 if executable('ag')
   " Use ag in CtrlP for listing files. Lightning fast and respects .gitignore
   let g:ctrlp_user_command =


### PR DESCRIPTION
After pulling the newest remote changes i got the following error when i have opened vim:

Error detected while processing /Users/kowa/.yadr/vim/settings/ctrlp.vim:
line    1:
E108: No such variable: "g:ctrlp_user_command"

This is because that variable has not been defined anywhere else. So we first have to check if this variable exists.
