### PR TITLE
fix colors in console vim on iterm2

### DIFF
--- a/vim/settings/yadr-appearance.vim
+++ b/vim/settings/yadr-appearance.vim
@@ -1,9 +1,5 @@
 " Make it beautiful - colors and fonts
 
-" http://ethanschoonover.com/solarized/vim-colors-solarized
-colorscheme solarized
-set background=dark
-
 if has("gui_running")
   "tell the term has 256 colors
   set t_Co=256
@@ -24,5 +20,11 @@ if has("gui_running")
 else
   "dont load csapprox if we no gui support - silences an annoying warning
   let g:CSApprox_loaded = 1
+  let g:solarized_termcolors=256
+  let g:solarized_termtrans=1
 endif
+
+" http://ethanschoonover.com/solarized/vim-colors-solarized
+colorscheme solarized
+set background=dark
 


### PR DESCRIPTION
Before patch:
![1 mvim vim 2014-06-13 13-38-45 2014-06-13 13-38-49](https://cloud.githubusercontent.com/assets/122018/3267235/5ef70c62-f2c7-11e3-956b-949461034ba6.png)
After patch:
![1 mvim vim 2014-06-13 13-39-34 2014-06-13 13-39-38](https://cloud.githubusercontent.com/assets/122018/3267236/62089a56-f2c7-11e3-8ecc-0973e1387d27.png)

maybe it solves https://github.com/skwp/dotfiles/issues/461 too
