### PR TITLE
0_path.zsh reinserts .yadr directories twice in $PATH when in tmux

### DIFF
--- a/zsh/0_path.zsh
+++ b/zsh/0_path.zsh
@@ -1,2 +1,7 @@
 # path, the 0 in the filename causes this to load first
-export PATH=$PATH:$HOME/.yadr/bin:$HOME/.yadr/bin/yadr
+path=(
+  $path
+  $HOME/.yadr/bin
+  $HOME/.yadr/bin/yadr
+)
+


### PR DESCRIPTION
in terminal

``` sh
sky@nimbus ~ $ echo $PATH 
/Users/sky/.rbenv/shims:/Users/sky/.rbenv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11/bin:/Users/sky/.yadr/bin:/Users/sky/.yadr/bin/yadr
```

in tmux

``` sh
sky@nimbus ~ $ echo $PATH
/Users/sky/.rbenv/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/X11/bin:/Users/sky/.rbenv/shims:/Users/sky/.yadr/bin:/Users/sky/.yadr/bin/yadr:/Users/sky/.yadr/bin:/Users/sky/.yadr/bin/yadr
```

Don't mind the differences in the first parts of the $PATH, ~~I think it's a separate prezto issue (I'm still not sure why).~~ It's best explained by this [issue (rbenv breaks inside of tmux)](https://github.com/sstephenson/rbenv/issues/369#issuecomment-22200587). You can choose not to read that issue as it is not related to this problem this PR is solving.

~~But~~ I've found that the part that adds `Users/sky/.yadr/bin:/Users/sky/.yadr/bin/yadr` twice in $PATH when using tmux is due to this part that unconditionally modifies $PATH.

Also see: http://stackoverflow.com/a/13060475
