### PR TITLE
Don't apply solarised settings to terminal vim

### DIFF
--- a/vim/settings/yadr-appearance.vim
+++ b/vim/settings/yadr-appearance.vim
@@ -20,8 +20,10 @@ if has("gui_running")
 else
   "dont load csapprox if we no gui support - silences an annoying warning
   let g:CSApprox_loaded = 1
-  let g:solarized_termcolors=256
-  let g:solarized_termtrans=1
+  if !exists("g:yadr_disable_solarized_enhancements")
+    let g:solarized_termcolors=256
+    let g:solarized_termtrans=1
+  endif
 endif
 
 " http://ethanschoonover.com/solarized/vim-colors-solarized


### PR DESCRIPTION
I've put it behind the new flag @skwp created but we could also just move it into the `if(has('gui_running'))` branch/statement.

What do you think @skwp??
# 

See #504 for discussion
