### PR TITLE
remove outdated git option

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -107,7 +107,7 @@
 [push]
   # 'git push' will push the current branch to its tracking branch
   # the usual default is to push all branches
-  default = tracking
+  default = upstream
 [core]
   autocrlf = false
   editor = vim


### PR DESCRIPTION
Hi,
git push tracking has been renamed: http://blogs.collab.net/cloudforge/tips-on-git-de-fanging-git-push#.U8eU9v5hOPI
