### PR TITLE
fixed the gitconfig.user path

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -124,4 +124,4 @@
   # http://gitfu.wordpress.com/2008/04/20/git-rerere-rereremember-what-you-did-last-time/
   enabled = true
 [include]
-  path = .gitconfig.user
+  path = ~/.gitconfig.user


### PR DESCRIPTION
changed the path for the gitconfig.user file to ~/.gitconfig.user

 Author:    Dave York dave.york@me.com
 Committer: Dave York dave.york@me.com
