### PR TITLE
Add `src` alias for `spring rails c`

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -145,6 +145,7 @@ alias zc='zeus console'
 # Rspec
 alias rs='rspec spec'
 alias sr='spring rspec'
+alias src='spring rails c'
 alias srgm='spring rails g migration'
 alias srdm='spring rake db:migrate'
 alias srdt='spring rake db:migrate'


### PR DESCRIPTION
In the same spirit of `srgm` for `spring rails g migration`, I've added a `src` alias for `spring rails c`.

I saw a `c` alias for `rails c`, but thought this new alias could be useful to.
