### PR TITLE
Make tmux pane resizing more natural

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -15,10 +15,10 @@ bind-key ^S split-window
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.
-bind-key J resize-pane -D
-bind-key K resize-pane -U
-bind-key H resize-pane -L
-bind-key L resize-pane -R
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
 
 # Use vi keybindings for tmux commandline input.
 # Note that to get command mode you need to hit ESC twice...


### PR DESCRIPTION
This feature allows the user to hold down H, J, K, L and have the pane size adjustment repeats. This means you don't have to keep repeating the key sequence `<C-a> {H,J,K,L}` over and over to adjust pane size.
