### PR TITLE
Ignoring just "tags" is too generic

### DIFF
--- a/git/gitignore
+++ b/git/gitignore
@@ -17,9 +17,19 @@ Desktop.ini
 
 # Tags      taken from: https://github.com/github/gitignore/blob/master/Global/Tags.gitignore
 # ----------------------------------------------------------------------------------------------
-# Ignore tags created by etags and ctags
+# Ignore tags created by etags, ctags, gtags (GNU global) and cscope
 TAGS
+!TAGS/
 tags
+!tags/
+gtags.files
+GTAGS
+GRTAGS
+GPATH
+cscope.files
+cscope.out
+cscope.in.out
+cscope.po.out
 
 # Vim       taken from: https://github.com/github/gitignore/blob/master/Global/vim.gitignore
 # ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
My application had a folder named "tags" as part of its business rules and because of this it got ignored.
I believe upadting this section according to the very link in the comment above should fix it. (not ignoring `tags/` folder).
