### PR TITLE
Remove deprecations from gemrc

### DIFF
--- a/ruby/gemrc
+++ b/ruby/gemrc
@@ -3,8 +3,6 @@
 :sources:
 - http://rubygems.org
 :benchmark: false
-:bulk_threshold: 1000
 :backtrace: false
 :verbose: true
-gem: --no-ri --no-rdoc
-
+gem: --no-document


### PR DESCRIPTION
Removed deprecated bulk_threshold-instance method:
http://www.rubydoc.info/github/rubygems/rubygems/Gem/ConfigFile#bulk_threshold-instance_method

--no-ri --no-rdoc is deprecated, use --no-document
Reference: http://guides.rubygems.org/command-reference/
