### PR TITLE
[Fix] Keybinding conflict introduced as part of #526.

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -26,8 +26,7 @@ bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE 
 bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-j) || tmux select-pane -D"
 bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-k) || tmux select-pane -U"
 bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys C-l) || tmux select-pane -R"
-# Conflicts with Nerdtree binding. Can possibly add back later under a different alias.
-#bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys 'C-\\') || tmux select-pane -l"
+bind -n C-\ run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)g?(view|vim?)(diff)?$' && tmux send-keys 'C-\\') || tmux select-pane -l"
 
 # Use vi keybindings for tmux commandline input.
 # Note that to get command mode you need to hit ESC twice...

--- a/vim/settings/vim-tmux-navigator.vim
+++ b/vim/settings/vim-tmux-navigator.vim
@@ -1,0 +1,10 @@
+" Don't allow any default key-mappings.
+let g:tmux_navigator_no_mappings = 1
+
+" Re-enable tmux_navigator.vim default bindings, minus <c-\>.
+" <c-\> conflicts with NERDTree "current file".
+
+nnoremap <silent> <c-h> :TmuxNavigateLeft<cr>
+nnoremap <silent> <c-j> :TmuxNavigateDown<cr>
+nnoremap <silent> <c-k> :TmuxNavigateUp<cr>
+nnoremap <silent> <c-l> :TmuxNavigateRight<cr>

--- a/vim/settings/yadr-keymap.vim
+++ b/vim/settings/yadr-keymap.vim
@@ -90,11 +90,12 @@ nnoremap <silent> ,x :bn<CR>
 " ==============================
 " Window/Tab/Split Manipulation
 " ==============================
-" Move between split windows by using the four directions H, L, I, N
-nnoremap <silent> <C-h> <C-w>h
-nnoremap <silent> <C-l> <C-w>l
-nnoremap <silent> <C-k> <C-w>k
-nnoremap <silent> <C-j> <C-w>j
+" Move between split windows by using the four directions H, L, K, J
+" NOTE: This has moved to vim/settings/vim-tmux-navigator.vim.
+" nnoremap <silent> <C-h> <C-w>h
+" nnoremap <silent> <C-l> <C-w>l
+" nnoremap <silent> <C-k> <C-w>k
+" nnoremap <silent> <C-j> <C-w>j
 
 " Make gf (go to file) create the file, if not existent
 nnoremap gf :e<cfile><CR>


### PR DESCRIPTION
Here's what I've done to test this fix:
- Fire up `vim` only (outside of `tmux`), create several splits. Verify that I am able to use `<c-{h,j,k,l}>` to move between them.
- Fire up `tmux` with two **_tmux**_ splits.
  1. In one of them (doesn't matter which), open up `vim` and create some **_vim**_ splits.
  2. Verify that I can move between both `tmux` and `vim` splits with the same `<c-{h,j,k,l}>` keys.
     - With cursor focus in `vim`, if I hit `<c-\>`, verify that the NERDTree panel is opened as expected.
     - With cursor focus in `tmux`, if I hit `<c-\>`, verify that the last active **_tmux**_ split is switched to.

Finally, what I _haven't_ tested are vim splits within GVim/MacVim. Outside of that, pending some sanity checks (cc: @skwp), I think this should be good to go functionality-wise.
