### PR TITLE
Update zprezto and enable tmux module

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -187,3 +187,6 @@ alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
 alias brewu='brew update && brew upgrade && brew cleanup && brew prune && brew doctor'
+
+# Simple server
+alias simplehttpserver='ruby -run -e httpd -- --port=8000 .'

--- a/zsh/prezto-override/zpreztorc
+++ b/zsh/prezto-override/zpreztorc
@@ -133,4 +133,4 @@ zstyle ':prezto:module:terminal' auto-title 'yes'
 
 # Auto start a session when Zsh is launched.
 # zstyle ':prezto:module:tmux:auto-start' remote 'yes'
-# zstyle ':prezto:module:tmux:auto-start' local 'yes'
+zstyle ':prezto:module:tmux:auto-start' remote 'yes'


### PR DESCRIPTION
Update zprezto, and also add the tmux module which give the ability to auto-start tmux when a shell logs in. Useful for persistent sessions on servers (disabled by default).
