### PR TITLE
Make tmux split exactly 50%

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -8,10 +8,10 @@ set -g default-terminal screen-256color
 bind-key ^D detach-client
 
 # Create splits and vertical splits
-bind-key v split-window -h -c "#{pane_current_path}"
-bind-key ^V split-window -h -c "#{pane_current_path}"
-bind-key s split-window -c "#{pane_current_path}"
-bind-key ^S split-window -c "#{pane_current_path}"
+bind-key v split-window -h -p 50 -c "#{pane_current_path}"
+bind-key ^V split-window -h -p 50 -c "#{pane_current_path}"
+bind-key s split-window -c -p 50 "#{pane_current_path}"
+bind-key ^S split-window -c -p 50 "#{pane_current_path}"
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.


### PR DESCRIPTION
Previously splits were not quite 50% by default. This fixes that. Makes working with things like https://github.com/jimeh/tmuxifier a breeze.
