### PR TITLE
Adding script to fix MacVim bug with external displays

### DIFF
--- a/bin/fix_macvim_external_display.sh
+++ b/bin/fix_macvim_external_display.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm ~/Library/Preferences/org.vim.MacVim.LSSharedFileList.plist && \
+rm ~/Library/Preferences/org.vim.MacVim.plist && \
+echo "Files deleted sucessfully. You may have to restart OSX."


### PR DESCRIPTION
Sometimes after connecting or diconnecting my MacBook from external display(s), MacVim won't start again next time.

It happend some 5 times with me already. The workaround is to delete some files and restart OSX, as described here:
http://stackoverflow.com/questions/17537871/macvim-failed-to-start-after-connecting-to-a-extra-display-and-disconnected

So I thought it would be nice to have this at hand once and for all...
