### PR TITLE
Fixed tmux.conf syntax after PR #565

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -10,8 +10,8 @@ bind-key ^D detach-client
 # Create splits and vertical splits
 bind-key v split-window -h -p 50 -c "#{pane_current_path}"
 bind-key ^V split-window -h -p 50 -c "#{pane_current_path}"
-bind-key s split-window -c -p 50 "#{pane_current_path}"
-bind-key ^S split-window -c -p 50 "#{pane_current_path}"
+bind-key s split-window -p 50 -c "#{pane_current_path}"
+bind-key ^S split-window -p 50 -c "#{pane_current_path}"
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.


### PR DESCRIPTION
PR #565 introduced 50% split in tmux, but created syntax error in tmux.conf.
Fixed here.
