### PR TITLE
Make Easymotion keys visible

### DIFF
--- a/doc/vim/navigation.md
+++ b/doc/vim/navigation.md
@@ -1,9 +1,9 @@
 * NERDTree - everyone's favorite tree browser
 * NERDTree-tabs - makes NERDTree play nice with MacVim tabs so that it's on every tab
 * ShowMarks - creates a visual gutter to the left of the number column showing you your marks
-* EasyMotion - hit ,<esc> (forward) or ,<Shift-Esc> (back) and watch the magic happen. Just type the letters and jump directly to your target - in the provided vimrc the keys are optimized for home row mostly. Using @skwp modified EasyMotion which uses vimperator-style two character targets.
-* TagBar - hit ,T to see a list of methods in a class (uses ctags)
-* CtrlP - ,t to find a file
-* Visual-star-search - make the * (star) search in visual mode behave like expected: searching for the whole selection instead of just the word under the cursor.
-* Ag - super fast search by Silver Searcher. hit `K` to grep current word
+* EasyMotion - hit <kbd>,</kbd> <kbd>esc</kbd> (forward) or <kbd>,</kbd> <kbd>Shift</kbd> <kbd>Esc</kbd> (back) and watch the magic happen. Just type the letters and jump directly to your target - in the provided vimrc the keys are optimized for home row mostly. Using @skwp modified EasyMotion which uses vimperator-style two character targets.
+* TagBar - hit <kbd>,</kbd> <kbd>T</kbd> to see a list of methods in a class (uses ctags)
+* CtrlP - <kbd>,</kbd> <kbd>t</kbd> to find a file
+* Visual-star-search - make the <kdb>*</kdb> (star) search in visual mode behave like expected: searching for the whole selection instead of just the word under the cursor.
+* Ag - super fast search by Silver Searcher. hit <kbd>K</kbd> to grep current word
 * vim-tmux-navigator - nagivate between vim and tmux splits in the same way you move between normal vim splits.


### PR DESCRIPTION
The current readme uses tag delimiters which results in part of the readme being hidden from the end user. It is also not obvious that the commas are keys and not just a break in the sentence. For this and other reasons I also wrapped all keys in the kdb tags were are specifically intended for this situation.