### PR TITLE
Remove orphan vim settings for LustyExplorer plugin

### DIFF
--- a/vim/settings/lusty-juggler.vim
+++ b/vim/settings/lusty-juggler.vim
@@ -1,3 +1,0 @@
-let g:LustyJugglerSuppressRubyWarning = 1
-let g:LustyJugglerAltTabMode = 1
-let g:LustyJugglerShowKeys = 'a' " show a/s/d/f keys 


### PR DESCRIPTION
I believe these settings are no longer relevant. I could not find any sign of the LustyExplorer in the project.
