### PR TITLE
Remove redundant persistent-undo.vim

### DIFF
--- a/vim/settings/persistent-undo.vim
+++ b/vim/settings/persistent-undo.vim
@@ -1,7 +1,0 @@
-" persistent undos - undo after you re-open the file
-" but this gives warnings under command line vim
-" use only in macvim
-if v:version > '702'
-  set undodir=~/.vim/backups
-  set undofile
-endif


### PR DESCRIPTION
Was doing some dotfiles maintenance and I noticed that the attached file (`vim/settings/persistent-undo.vim`) is unnecessary/inferior due to:  [vimrc#L49](https://github.com/skwp/dotfiles/blob/master/vimrc#L49).