### PR TITLE
Remove duplicate window split mappings

### DIFF
--- a/vim/settings/yadr-keymap-linux.vim
+++ b/vim/settings/yadr-keymap-linux.vim
@@ -58,12 +58,6 @@ map <silent> <A-7> :tabn 7<cr>
 map <silent> <A-8> :tabn 8<cr>
 map <silent> <A-9> :tabn 9<cr>
 
-" Create window splits easier. The default
-" way is Ctrl-w,v and Ctrl-w,s. I remap
-" this to vv and ss
-nnoremap <silent> vv <C-w>v
-nnoremap <silent> ss <C-w>s
-
 " Resize windows with arrow keys
 nnoremap <C-Up> <C-w>+
 nnoremap <C-Down> <C-w>-

--- a/vim/settings/yadr-keymap-mac.vim
+++ b/vim/settings/yadr-keymap-mac.vim
@@ -58,12 +58,6 @@ map <silent> <D-7> :tabn 7<cr>
 map <silent> <D-8> :tabn 8<cr>
 map <silent> <D-9> :tabn 9<cr>
 
-" Create window splits easier. The default
-" way is Ctrl-w,v and Ctrl-w,s. I remap
-" this to vv and ss
-nnoremap <silent> vv <C-w>v
-nnoremap <silent> ss <C-w>s
-
 " Resize windows with arrow keys
 nnoremap <D-Up> <C-w>+
 nnoremap <D-Down> <C-w>-


### PR DESCRIPTION
Window split mappings are declared in the [shared mappings file](https://github.com/skwp/dotfiles/blob/master/vim/settings/yadr-keymap.vim#L108) and duplicated Mac and Linux mappings files.

This removes the duplication in favour of using the declaration from the shared mappings.