### PR TITLE
Updating github raw userdata urls to githubusercontent.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     # Yet Another Dotfile Repo v1.1
     # Now with Prezto and Vundle!
 
-    sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`"
+    sh -c "`curl -fsSL https://raw.githubusercontent.com/skwp/dotfiles/master/install.sh`"
 
 **Always be sure to run `rake update` after pulling to ensure plugins are updated**
 
@@ -36,14 +36,14 @@ Please use GitHub Issues for pull requests or bug reports only.
 To get started please run:
 
 ```bash
-sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`"
+sh -c "`curl -fsSL https://raw.githubusercontent.com/skwp/dotfiles/master/install.sh`"
 ```
 
 **Note:** YADR will automatically install all of its subcomponents. If you want to be asked
 about each one, use:
 
 ```bash
-sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`" -s ask
+sh -c "`curl -fsSL https://raw.githubusercontent.com/skwp/dotfiles/master/install.sh`" -s ask
 ```
 
 ## Wait, you're not done! Do this:


### PR DESCRIPTION
Github changed user content urls:
https://developer.github.com/changes/2014-04-25-user-content-security/

Old one doesn't work correctly. For example:

```
sh -c "`curl -fsSL https://raw.github.com/skwp/dotfiles/master/install.sh`"
curl: (22) The requested URL returned error: 400 Bad Request
```