### PR TITLE
install AND update vundles on rake update

### DIFF
--- a/bin/yadr/vundle.rb
+++ b/bin/yadr/vundle.rb
@@ -26,7 +26,7 @@ module Vundle
   end
 
   def self.update_vundle
-    system "vim --noplugin -u #{ENV['HOME']}/.vim/vundles.vim -N \"+set hidden\" \"+syntax on\" +BundleClean +BundleInstall +qall"
+    system "vim --noplugin -u #{ENV['HOME']}/.vim/vundles.vim -N \"+set hidden\" \"+syntax on\" +BundleClean +BundleInstall! +qall"
   end
 
 


### PR DESCRIPTION
Following on from https://github.com/skwp/dotfiles/issues/588#issuecomment-69034629, vundle has [:BundelInstall!](https://github.com/gmarik/Vundle.vim/blob/v0.10.2/doc/vundle.txt#L258), that has been around since at least [2011](https://github.com/gmarik/Vundle.vim/blob/289332e2aee3e6b79d40d488b412b1f873a66df2/README.md) (the documentation was confusing before that, but I think it has always been there and done the same thing).