### PR TITLE
[Improvement] Search Settings

### DIFF
--- a/vim/settings/yadr-search.vim
+++ b/vim/settings/yadr-search.vim
@@ -1,8 +1,0 @@
-" ================ Search Settings  =================
-
-set incsearch       " Find the next match as we type the search
-set hlsearch        " Hilight searches by default
-set viminfo='100,f1 " Save up to 100 marks, enable capital marks
-set ignorecase      " Ignore case when searching...
-set smartcase       " ...unless we type a capital
-

--- a/vimrc
+++ b/vimrc
@@ -102,6 +102,12 @@ set scrolloff=8         "Start scrolling when we're 8 lines away from margins
 set sidescrolloff=15
 set sidescroll=1
 
+" ================ Search ===========================
+
+set incsearch       " Find the next match as we type the search
+set hlsearch        " Highlight searches by default
+set ignorecase      " Ignore case when searching...
+set smartcase       " ...unless we type a capital
 
 " ================ Custom Settings ========================
 so ~/.yadr/vim/settings.vim


### PR DESCRIPTION
This PR does two things (happy to split them if the latter is controversial):

1. Move `vim/settings/yadr-search.vim` options back into `vimrc`. I see the appeal in separating out many of the settings files, but this one belongs in a `vimrc` in my opinion (among other reasons, it's way too easy to miss). `vim/settings` should be reserved for customizations like keybindings, plugins, etc... rather than core Vim settings.

2. Remove the line pertaining to `viminfo`. The default includes `'100`, and I'm not convinced that the `f1` option is necessary:

> Source: http://vimdoc.sourceforge.net/htmldoc/usr_21.html

> The f option controls whether global marks (A-Z and 0-9) are stored.  If this
option is 0, none are stored.  If it is 1 **or you do not specify an f option**,
the marks are stored.  You want this feature, so now you have this:

>	:set viminfo='1000,f1

On Vim 7.4 1-488, the defaults are: `set viminfo='100,<50,s10,h` which are essentially what it was set to explicitly before, plus some other reasonable settings.

If it turns out the `f1` option doesn't come for free, I think it should be instead: `set viminfo+=f1` rather than clobbering it.

In any situation, the reason why the `viminfo` line is significant is because removing the `,h` option causes Vim to re-open with search highlighting already enabled based on the last search you made before Vim closed which is silly (and was making me go bananas) :smile: 

With this, a simple press of `n` (as in next search item) will re-enable search highlighting (similar to `:noh`) if you really wish to re-perform the last search before Vim closed. But 95 times out of 100 for me, that's not the case and the highlighting is super annoying.

Just to be clear, this doesn't touch the `hlsearch` option being on by default. The only affect it has on search highlighting is to disable it **coming into Vim before a search is performed**. As of now, it's as if a search has already been performed based on the last search in the history when entering Vim (which doesn't make any sense as a default in my opinion).