### PR TITLE
Change the NERDTreeFind keymap to not statically set the nerdtree window size

### DIFF
--- a/vim/settings/yadr-keymap.vim
+++ b/vim/settings/yadr-keymap.vim
@@ -75,7 +75,7 @@ imap <C-a> <esc>wa
 
 " ==== NERD tree
 " Open the project tree and expose current file in the nerdtree with Ctrl-\
-nnoremap <silent> <C-\> :NERDTreeFind<CR>:vertical res 30<CR>
+nnoremap <silent> <C-\> :NERDTreeFind<CR>:vertical<CR>
 
 " ,q to toggle quickfix window (where you have stuff like Ag)
 " ,oq to open it back up (rare)


### PR DESCRIPTION
With this change users can now change the variable g:NERDTreeWinSize and have it applied
to new instances of NERDTree created with the NERDTreeFind keymap `ctrl-\`

This addresses https://github.com/skwp/dotfiles/issues/594