### PR TITLE
Make installation more faster

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 if [ ! -d "$HOME/.yadr" ]; then
     echo "Installing YADR for the first time"
-    git clone https://github.com/skwp/dotfiles.git "$HOME/.yadr"
+    git clone --depth=1 https://github.com/skwp/dotfiles.git "$HOME/.yadr"
     cd "$HOME/.yadr"
     [ "$1" = "ask" ] && export ASK="true"
     rake install


### PR DESCRIPTION
The installation script should not clone the whole commit history. By adding `--depth=1` it will clone only the latest commit history and make installation process more faster.