### PR TITLE
Update `brewu` alias to use `upgrade --all` for future proofing

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -189,4 +189,4 @@ alias dbmd='spring rake db:migrate:down'
 alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
-alias brewu='brew update --all && brew upgrade && brew cleanup && brew prune && brew doctor'
+alias brewu='brew update  && brew upgrade --all && brew cleanup && brew prune && brew doctor'

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -189,4 +189,4 @@ alias dbmd='spring rake db:migrate:down'
 alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
-alias brewu='brew update && brew upgrade && brew cleanup && brew prune && brew doctor'
+alias brewu='brew update --all && brew upgrade && brew cleanup && brew prune && brew doctor'


### PR DESCRIPTION
Running `$ brew update` now returns 

    Warning: brew upgrade with no arguments will change behaviour soon!
    It currently upgrades all formula but this will soon change to require '--all'.
    Please update any workflows, documentation and scripts!

This PR addresses that.