### PR TITLE
Fix tmux.conf

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -8,10 +8,10 @@ set -g default-terminal screen-256color
 bind-key ^D detach-client
 
 # Create splits and vertical splits
-bind-key v split-window -h -p 50 -c "#{pane_current_path}"
-bind-key ^V split-window -h -p 50 -c "#{pane_current_path}"
-bind-key s split-window -p 50 -c "#{pane_current_path}"
-bind-key ^S split-window -p 50 -c "#{pane_current_path}"
+bind-key v split-window -h -p 50 -F "#{pane_current_path}"
+bind-key ^V split-window -h -p 50 -F "#{pane_current_path}"
+bind-key s split-window -p 50 -F "#{pane_current_path}"
+bind-key ^S split-window -p 50 -F "#{pane_current_path}"
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -77,7 +77,7 @@ bind C-a last-window
 set -g history-limit 10000
 
 # New windows/pane in $PWD
-bind c new-window -c "#{pane_current_path}"
+bind c new-window -F "#{pane_current_path}"
 
 # force a reload of the config file
 unbind r


### PR DESCRIPTION
Fix tmux "open new pane in current path" option.

It is necessary to use `-F` when using replacement variables.