### PR TITLE
Alias vim to stop stty and then start vim

### DIFF
--- a/zsh/zsh-aliases.zsh
+++ b/zsh/zsh-aliases.zsh
@@ -9,6 +9,11 @@ alias -g N="| /dev/null"
 alias -g S='| sort'
 alias -g G='| grep' # now you can do: ls foo G something
 
+# Allow use of <C-s> in terminal vim
+alias vim="stty stop '' -ixoff ; vim"
+# Restart stty after any terminal command
+ttyctl -f
+
 # Functions
 #
 # (f)ind by (n)ame


### PR DESCRIPTION
This way, if you use vim in the terminal, you can use `ctrl-s` as a keyboard shortcut. Otherwise, the terminal intercepts the `ctrl-s` and treats it as an instruction to stop output. In yadr this is bound to opening the related spec file in ruby projects.