### PR TITLE
[WIP] Source vimrc.after

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -115,3 +115,7 @@ set smartcase       " ...unless we type a capital
 
 " ================ Custom Settings ========================
 so ~/.yadr/vim/settings.vim
+
+if filereadable(expand("~/.vimrc.after"))
+  source ~/.vimrc.after
+endif


### PR DESCRIPTION
The documentation says we should place overrides in `.yadr/vim/.vimrc.after` but that file is never sourced and as a result, overrides don't work. I'm not sure if this is the right place to put it so I'm happy to update the PR with the right way.

Cheers

cc @skwp 