### PR TITLE
Fix iTerm key bindings broken in tmux 2.1

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -79,6 +79,9 @@ set -g history-limit 10000
 # New windows/pane in $PWD
 bind c new-window -c "#{pane_current_path}"
 
+# Fix key bindings broken in tmux 2.1
+set -g assume-paste-time 0
+
 # force a reload of the config file
 unbind r
 bind r source-file ~/.tmux.conf \; display "Reloaded!"


### PR DESCRIPTION
Key bindings in iTerm 2.1.4 that send multiple hex codes are received by tmux 2.1 in the incorrect sequence. For example, a hex code key binding that sends `0x02 0x31` (Ctrl-B,1) will be received by tmux as 0x31 0x02. Setting tmux's `assume-paste-time` to 0 fixes this.

Reference: http://superuser.com/questions/989887/key-bindings-broken-in-tmux-2-1
