### PR TITLE
Extend word to recognize '?' as part of it

### DIFF
--- a/vim/settings/search.vim
+++ b/vim/settings/search.vim
@@ -19,6 +19,9 @@ vnoremap K :<C-U>execute "Ag " . GetVisual()<CR>
 "grep current word up to the next exclamation point using ,K
 nnoremap ,K viwf!:<C-U>execute "Ag " . GetVisual()<CR>
 
+"add ? to be recognized as part of a word
+set iskeyword+=?
+
 "grep for 'def foo'
 nnoremap <silent> ,gd :Ag 'def <cword>'<CR>
 


### PR DESCRIPTION
When you're looking for a method name that contains a '?' (common on ruby) now it includes it on the search.

Now when you do something like `,K` or `,gd` on a method name that includes '?' it will include the '?' on the search.