### PR TITLE
updated command to avoid warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,6 @@ brew cleanup
 brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit
 ```
 
-
-
 ### Terminal Vim troubles with Lua?
 Installing terminal vim (with lua) with an RVM managed Ruby can cause the neocomplete plugin to segfault. Try uninstalling vim, then installing with system ruby:
 

--- a/README.md
+++ b/README.md
@@ -300,8 +300,10 @@ These hacks are Lion-centric. May not work for other OS'es. My favorite mods inc
 brew uninstall macvim
 brew remove macvim
 brew cleanup
-brew install macvim --custom-icons --override-system-vim --with-lua --with-luajit
+brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit
 ```
+
+
 
 ### Terminal Vim troubles with Lua?
 Installing terminal vim (with lua) with an RVM managed Ruby can cause the neocomplete plugin to segfault. Try uninstalling vim, then installing with system ruby:

--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher}
-  run %{brew install macvim --custom-icons --override-system-vim --with-lua --with-luajit}
+  run %{brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit}
   puts
   puts
 end


### PR DESCRIPTION
When running the brew install command with `--override-system-vim` the following warning is triggered
```bash
Warning: macvim: --override-system-vim was deprecated; using --with-override-system-vim instead!
```
So I fixed the command to avoid showing the warning.