### PR TITLE
Don't append already existing content to .zshrc on rake update

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -323,9 +323,12 @@ def install_files(files, method = :symlink)
     # Temporary solution until we find a way to allow customization
     # This modifies zshrc to load all of yadr's zsh extensions.
     # Eventually yadr's zsh extensions should be ported to prezto modules.
+    source_config_code = "for config_file ($HOME/.yadr/zsh/*.zsh) source $config_file"
     if file == 'zshrc'
-      File.open(target, 'a') do |zshrc|
-        zshrc.puts('for config_file ($HOME/.yadr/zsh/*.zsh) source $config_file')
+      File.open(target, 'a+') do |zshrc|
+        if zshrc.readlines.grep(/#{Regexp.escape(source_config_code)}/).empty?
+          zshrc.puts(source_config_code)
+        end
       end
     end
 


### PR DESCRIPTION
- Modifies `Rakefile` to check `~/.zshrc` for presence of string `"for config_file ($HOME/.yadr/zsh/*.zsh) source $config_file"` before appending it. 

> I was ending up with duplicates of that line every time I ran `rake update`