### PR TITLE
Updated the macvim param

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher}
-  run %{brew install macvim --custom-icons --override-system-vim --with-lua --with-luajit}
+  run %{brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit}
   puts
   puts
 end


### PR DESCRIPTION
--override-system-vim is now supposed to be --with-override-system-vim