### PR TITLE
Replacing "--override-system-vim" with "--with-override-system-vim"

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ These hacks are Lion-centric. May not work for other OS'es. My favorite mods inc
 brew uninstall macvim
 brew remove macvim
 brew cleanup
-brew install macvim --custom-icons --override-system-vim --with-lua --with-luajit
+brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit
 ```
 
 ### Terminal Vim troubles with Lua?

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,11 @@ task :install => [:submodule_init, :submodules] do
   puts "Welcome to YADR Installation."
   puts "======================================================"
   puts
+  
+  if RUBY_PLATFORM.downcase.include?("darwin")
+    puts "Password for sudo - we need it sometimes"
+    run %{ sudo -v}
+  end
 
   install_homebrew if RUBY_PLATFORM.downcase.include?("darwin")
   install_rvm_binstubs

--- a/Rakefile
+++ b/Rakefile
@@ -323,9 +323,12 @@ def install_files(files, method = :symlink)
     # Temporary solution until we find a way to allow customization
     # This modifies zshrc to load all of yadr's zsh extensions.
     # Eventually yadr's zsh extensions should be ported to prezto modules.
+    source_config_code = "for config_file ($HOME/.yadr/zsh/*.zsh) source $config_file"
     if file == 'zshrc'
-      File.open(target, 'a') do |zshrc|
-        zshrc.puts('for config_file ($HOME/.yadr/zsh/*.zsh) source $config_file')
+      File.open(target, 'a+') do |zshrc|
+        if zshrc.readlines.grep(/#{Regexp.escape(source_config_code)}/).empty?
+          zshrc.puts(source_config_code)
+        end
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher}
-  run %{brew install macvim --custom-icons --override-system-vim --with-lua --with-luajit}
+  run %{brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit}
   puts
   puts
 end

--- a/vim/settings/solarized.vim
+++ b/vim/settings/solarized.vim
@@ -68,7 +68,7 @@ if !exists("g:yadr_disable_solarized_enhancements")
   hi! Comment guifg=#52737B
   hi! link htmlLink Include
   hi! CursorLine cterm=NONE gui=NONE
-  hi! Visual ctermbg=233
+  hi! Visual ctermbg=233 guibg=#0000FF
   hi! Type gui=bold
   hi! EasyMotionTarget ctermfg=100 guifg=#4CE660 gui=bold
 


### PR DESCRIPTION
--override-system-vim is deprecated and got replaced with --with-override-system-vim