### PR TITLE
Add: Vim plugin: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+charset = utf-8

--- a/vim/vundles/vim-improvements.vundle
+++ b/vim/vundles/vim-improvements.vundle
@@ -27,3 +27,5 @@ Bundle "vim-scripts/AutoTag.git"
 Bundle "vim-scripts/lastpos.vim"
 Bundle "vim-scripts/sudo.vim"
 Bundle "goldfeld/ctrlr.vim"
+Bundle "editorconfig/editorconfig-vim"
+


### PR DESCRIPTION
This PR consists of add a plugin and its according config file for this very repo.
It is a nice, official plugin for VIM, amply supported in several IDEs already. Its goal is to normalize things like indentation, file encoding, line endings and etc across different IDEs and OSes.

See http://editorconfig.org/ for more details and examples.

I created yadr's `.editorconfig` based on what I see in the existing files... Let me know if something's off.