### PR TITLE
Remove old references to plugins

### DIFF
--- a/doc/vim/navigation.md
+++ b/doc/vim/navigation.md
@@ -2,7 +2,6 @@
 * NERDTree-tabs - makes NERDTree play nice with MacVim tabs so that it's on every tab
 * ShowMarks - creates a visual gutter to the left of the number column showing you your marks
 * EasyMotion - hit <kbd>,</kbd> <kbd>esc</kbd> (forward) or <kbd>,</kbd> <kbd>Shift</kbd> <kbd>Esc</kbd> (back) and watch the magic happen. Just type the letters and jump directly to your target - in the provided vimrc the keys are optimized for home row mostly. Using @skwp modified EasyMotion which uses vimperator-style two character targets.
-* TagBar - hit <kbd>,</kbd> <kbd>T</kbd> to see a list of methods in a class (uses ctags)
 * CtrlP - <kbd>,</kbd> <kbd>t</kbd> to find a file
 * Visual-star-search - make the <kbd>*</kbd> (star) search in visual mode behave like expected: searching for the whole selection instead of just the word under the cursor.
 * Ag - super fast search by Silver Searcher. hit <kbd>K</kbd> to grep current word

--- a/doc/vim/utils.md
+++ b/doc/vim/utils.md
@@ -3,8 +3,6 @@
 * yankring - effortless sanity for pasting. every time you yank something it goes into a buffer. after hitting p to paste, use ctrl-p or ctrl-n to cycle through the paste options. great for when you accidentally overwrite your yank with a delete.
 * surround - super easy quote and tag manipulation - ysiw" - sourround inner word with quotes. ci"' - change inner double quotes to single quotes, etc
 * greplace - use :Gsearch to find across many files, replace inside the changes, then :Greplace to do a replace across all matches - made lightning fast with Silver Searcher
-* ConqueTerm - embedded fully colorful shell inside your vim
-* vim-ruby-conque - helpers to run ruby,rspec,rake within ConqueTerm
 * vim-markdown-preview - :Mm to view your README.md as html
 * html-escape - ,he and ,hu to escape and unescape html
 * Gundo - visualize your undos - pretty amazing plugin. Hit ,u with my keymappings to trigger it, very user friendly


### PR DESCRIPTION
I noticed that TagBar and Conque are no more, but I found those references in the docs...