### PR TITLE
Fixed GUI visual mode highlight color

### DIFF
--- a/vim/settings/solarized.vim
+++ b/vim/settings/solarized.vim
@@ -68,7 +68,7 @@ if !exists("g:yadr_disable_solarized_enhancements")
   hi! Comment guifg=#52737B
   hi! link htmlLink Include
   hi! CursorLine cterm=NONE gui=NONE
-  hi! Visual ctermbg=233
+  hi! Visual ctermbg=021 guibg=#0000FF
   hi! Type gui=bold
   hi! EasyMotionTarget ctermfg=100 guifg=#4CE660 gui=bold
 


### PR DESCRIPTION
#646
Fixed VIM's visual mode incorrect background color in MacVim GUI mode
