### PR TITLE
Added higlight to zoomed window

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -56,7 +56,7 @@ set -g message-bg colour221
 set -g message-attr bold
 set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
 set -g window-status-format "#[fg=colour235,bg=colour252,bold] #I #W "
-set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #I: #W #[fg=colour39,bg=colour234,nobold]⮀"
+set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour226],} #I: #W #[fg=colour39,bg=colour234,nobold]⮀"
 
 # Patch for OS X pbpaste and pbcopy under tmux.
 set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"


### PR DESCRIPTION
Currently there's no way of seeing a window in tmux is zoomed (prefix z), this ads some highlighting.