### PR TITLE
Add vim shortcut: copy the relative path of a file

### DIFF
--- a/vim/settings/yadr-keymap.vim
+++ b/vim/settings/yadr-keymap.vim
@@ -131,6 +131,7 @@ imap <silent> <C-J> <%  %><Esc>2hi
 " copy current filename into system clipboard - mnemonic: (c)urrent(f)ilename
 " this is helpful to paste someone the path you're looking at
 nnoremap <silent> ,cf :let @* = expand("%:~")<CR>
+nnoremap <silent> ,cr :let @* = expand("%")<CR>
 nnoremap <silent> ,cn :let @* = expand("%:t")<CR>
 
 "Clear current search highlight by double tapping //


### PR DESCRIPTION
I've been using ,cf for some of the time, but sometimes I don't want the full path for a variety of reasons:
- any command where relative path suffices (running tests, removing files)
- the full path won't work if I'm using MacVim and the project is within vagrant cli