### PR TITLE
remove bitdeli.com broken image

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,5 +321,3 @@ Pry offers a much better out of the box IRB experience with colors, tab completi
 as an actual debugger by installing [pry-nav](https://github.com/nixme/pry-nav).
 
 [Learn more about YADR's pry customizations and how to install](doc/pry.md)
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/skwp/dotfiles/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
https://bitdeli.com/ - looks like they down, I don't know if it's just a long downtime, but looks like they are not supporting the site anymore.