### PR TITLE
Revert ef2156144f726ef8328e7dc299cf8e0b6b459127

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -8,10 +8,10 @@ set -g default-terminal screen-256color
 bind-key ^D detach-client
 
 # Create splits and vertical splits
-bind-key v split-window -h -p 50 -F "#{pane_current_path}"
-bind-key ^V split-window -h -p 50 -F "#{pane_current_path}"
-bind-key s split-window -p 50 -F "#{pane_current_path}"
-bind-key ^S split-window -p 50 -F "#{pane_current_path}"
+bind-key v split-window -h -p 50 -c "#{pane_current_path}"
+bind-key ^V split-window -h -p 50 -c "#{pane_current_path}"
+bind-key s split-window -p 50 -c "#{pane_current_path}"
+bind-key ^S split-window -p 50 -c "#{pane_current_path}"
 
 # Pane resize in all four directions using vi bindings.
 # Can use these raw but I map them to shift-ctrl-<h,j,k,l> in iTerm.
@@ -78,7 +78,7 @@ bind C-a last-window
 set -g history-limit 10000
 
 # New windows/pane in $PWD
-bind c new-window -F "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
 
 # Fix key bindings broken in tmux 2.1
 set -g assume-paste-time 0


### PR DESCRIPTION
#656 introduced breaking changes without any explanation.
This reverts a fix that broke what was not broken.

In case of new-window and split-window:

- `-F` formats `-P` output
- `-c` sets a working directory
- `-F` is not a replacement to `-c`

```
     new-window [-adkP] [-c start-directory] [-F format] [-n window-name]
             [-t target-window] [shell-command]
                   (alias: neww)
             Create a new window.  With -a, the new window is inserted at
             the next index up from the specified target-window, moving win‐
             dows up if necessary, otherwise target-window is the new window
             location.

             If -d is given, the session does not make the new window the
             current window.  target-window represents the window to be cre‐
             ated; if the target already exists an error is shown, unless
             the -k flag is used, in which case it is destroyed.
             shell-command is the command to execute.  If shell-command is
             not specified, the value of the default-command option is used.
             -c specifies the working directory in which the new window is
             created.

             When the shell command completes, the window closes.  See the
             remain-on-exit option to change this behaviour.

             The TERM environment variable must be set to “screen” for all
             programs running inside tmux.  New windows will automatically
             have “TERM=screen” added to their environment, but care must be
             taken not to reset this in shell start-up files.

             The -P option prints information about the new window after it
             has been created.  By default, it uses the format
             ‘#{session_name}:#{window_index}’ but a different format may be
             specified with -F.
```
```
    split-window [-bdhvP] [-c start-directory] [-l size | -p percentage]
             [-t target-pane] [shell-command] [-F format]
                   (alias: splitw)
             Create a new pane by splitting target-pane: -h does a horizon‐
             tal split and -v a vertical split; if neither is specified, -v
             is assumed.  The -l and -p options specify the size of the new
             pane in lines (for vertical split) or in cells (for horizontal
             split), or as a percentage, respectively.  The -b option causes
             the new pane to be created to the left of or above target-pane.

             All other options have the same meaning as for the new-window
             command.
```