### PR TITLE
Auto setup eslint with fallback to standard linter

### DIFF
--- a/vim/settings/syntastic.vim
+++ b/vim/settings/syntastic.vim
@@ -7,9 +7,35 @@ let g:syntastic_auto_loc_list=1
 "don't care about warnings
 let g:syntastic_quiet_messages = {'level': 'warnings'}
 
-" Default to eslint. If you need jshint, you can override this in
-" ~/.vimrc.after
-let g:syntastic_javascript_checkers = ['eslint']
+"
+" Javascript
+"
+
+let g:syntastic_javascript_checkers = []
+
+function CheckJavaScriptLinter(filepath, linter)
+  if exists('b:syntastic_checkers')
+    return
+  endif
+  if filereadable(a:filepath)
+    let b:syntastic_checkers = [a:linter]
+    let {'b:syntastic_' . a:linter . '_exec'} = a:filepath
+  endif
+endfunction
+
+function SetupJavaScriptLinter()
+    let l:current_folder = expand('%:p:h')
+    let l:bin_folder = fnamemodify(syntastic#util#findFileInParent('package.json', l:current_folder), ':h')
+    let l:bin_folder = l:bin_folder . '/node_modules/.bin/'
+    call CheckJavaScriptLinter(l:bin_folder . 'standard', 'standard')
+    call CheckJavaScriptLinter(l:bin_folder . 'eslint', 'eslint')
+endfunction
+
+autocmd FileType javascript call SetupJavaScriptLinter()
+
+"
+" Ruby
+"
 
 " I have no idea why this is not working, as it used to
 " be a part of syntastic code but was apparently removed


### PR DESCRIPTION
This PR does 2 things:
1. Check for `eslint` presence. If it's there, use it. Otherwise, use `standard` linter. Otherwise, none.
2. it sets eslint's executable to the local one (inside `node_modules`)

Courtesy of http://nunes.io/notes/guide/vim-how-to-setup-eslint/

Cheers
