### PR TITLE
fix: removed obsolete --all flag from brew upgrade

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -210,4 +210,4 @@ alias dbmd='spring rake db:migrate:down'
 alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
-alias brewu='brew update  && brew upgrade --all && brew cleanup && brew prune && brew doctor'
+alias brewu='brew update  && brew upgrade && brew cleanup && brew prune && brew doctor'


### PR DESCRIPTION
This --all flag only produces a warning in homebrew, so it can be removed...