### PR TITLE
Remap K to ,k for search so you don't accidentally lock up vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ of plugins above to learn more.
  * `,F` - same as `,f` but in a vertical split
  * `,gf` or `Ctrl-f` - same as vim normal gf (go to file), but in a vertical split (works with file.rb:123 line numbers also)
  * `gF` - standard vim mapping, here for completeness (go to file at line number)
- * `K` - Search the current word under the cursor and show results in quickfix window
+ * `,k` - Search the current word under the cursor and show results in quickfix window
  * `,K` - Grep the current word up to next exclamation point (useful for ruby foo! methods)
  * `Cmd-*` - highlight all occurrences of current word (similar to regular `*` except doesn't move)
  * `,hl` - toggle search highlight on and off
@@ -200,7 +200,7 @@ of plugins above to learn more.
  * `gK` - Opens the documentation for the word under the cursor.
  * Spacebar - Sneak - type two characters to move there in a line. Kind of like vim's `f` but more accurate.
  * `:Gsearch foo` - global search, then do your normal `%s/search/replace/g` and follow up with `:Greplace` to replace across all files. When done use `:wall` to write all the files.
- 
+
 
 #### File Navigation
 

--- a/vim/settings/search.vim
+++ b/vim/settings/search.vim
@@ -10,11 +10,11 @@ function! GetVisual()
   return selection
 endfunction
 
-"grep the current word using K (mnemonic Kurrent)
-nnoremap <silent> K :Ag <cword><CR>
+"grep the current word using ,k (mnemonic Kurrent)
+nnoremap <silent> ,k :Ag <cword><CR>
 
 "grep visual selection
-vnoremap K :<C-U>execute "Ag " . GetVisual()<CR>
+vnoremap ,k :<C-U>execute "Ag " . GetVisual()<CR>
 
 "grep current word up to the next exclamation point using ,K
 nnoremap ,K viwf!:<C-U>execute "Ag " . GetVisual()<CR>


### PR DESCRIPTION
People were complaining that "K" was too easy to hit by accident on a random char and search a large codebase.