### PR TITLE
Display forder name on tmux's window status

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -56,8 +56,9 @@ set -g message-fg colour16
 set -g message-bg colour221
 set -g message-attr bold
 set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
-set -g window-status-format "#[fg=colour235,bg=colour252,bold] #I #W "
-set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour226],} #I: #W #[fg=colour39,bg=colour234,nobold]⮀"
+set -g window-status-format '#[fg=colour235,bg=colour252,bold] #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W '
+set -g window-status-current-format '#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour228],} #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W #[fg=colour39,bg=colour234,nobold]⮀'
+set-option -g status-interval 2
 
 # Patch for OS X pbpaste and pbcopy under tmux.
 set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"


### PR DESCRIPTION
I found this super useful and worth to share.

<img width="767" alt="screen shot 2017-04-12 at 2 21 28 pm" src="https://cloud.githubusercontent.com/assets/850686/24980269/6091a182-1f8c-11e7-9f77-b12596e5652d.png">

`core-server` and `gear-server` are my folder's names