### PR TITLE
Fix trailing chars E488 Error when :Wrap

### DIFF
--- a/vim/settings/yadr-wrapping.vim
+++ b/vim/settings/yadr-wrapping.vim
@@ -5,7 +5,7 @@ function! SetupWrapping()
 endfunction
 
 " TODO: this should happen automatically for certain file types (e.g. markdown)
-command! -nargs=* Wrap :call SetupWrapping()<CR>
+command! -nargs=* Wrap call SetupWrapping()
 
 vmap <D-j> gj
 vmap <D-k> gk
@@ -17,4 +17,3 @@ nmap <D-k> gk
 nmap <D-$> g$
 nmap <D-^> g^
 nmap <D-0> g^
-


### PR DESCRIPTION
It was working but every time I'd use `:Wrap` I'd get the E488 error. This fixes that.