### PR TITLE
Enable mouse support for tmux 2.1+

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -44,7 +44,7 @@ bind E setw synchronize-panes off
 # set first window to index 1 (not 0) to map more to the keyboard layout...
 set-option -g base-index 1
 set-window-option -g pane-base-index 1
-set-window-option -g mode-mouse on
+set-window-option -g mouse on
 
 # color scheme (styled as vim-powerline)
 set -g status-left-length 52


### PR DESCRIPTION
`mode-mouse` is not used since tmux 2.1.

It can be checked at the [changelog](https://github.com/tmux/tmux/blob/2.1/CHANGES#L6L13) or at the manual, [here](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#mouse) and [here](http://man.openbsd.org/OpenBSD-current/man1/tmux.1#MOUSE_SUPPORT)