### PR TITLE
Prevent duplicate entries in $PATH. Fixes #690

### DIFF
--- a/zsh/0_path.zsh
+++ b/zsh/0_path.zsh
@@ -1,7 +1,14 @@
 # path, the 0 in the filename causes this to load first
-path=(
-  $path
-  $HOME/.yadr/bin
-  $HOME/.yadr/bin/yadr
-)
+#
+# If you have duplicate entries on your PATH, run this command to fix it:
+# PATH=$(echo "$PATH" | awk -v RS=':' -v ORS=":" '!a[$1]++{if (NR > 1) printf ORS; printf $a[$1]}')
 
+pathAppend() {
+  # Only adds to the path if it's not already there
+  if ! echo $PATH | egrep -q "(^|:)$1($|:)" ; then
+    PATH=$PATH:$1
+  fi
+}
+
+pathAppend "$HOME/.yadr/bin"
+pathAppend "$HOME/.yadr/bin/yadr"

--- a/zsh/0_path.zsh
+++ b/zsh/0_path.zsh
@@ -1,7 +1,4 @@
 # path, the 0 in the filename causes this to load first
-#
-# If you have duplicate entries on your PATH, run this command to fix it:
-# PATH=$(echo "$PATH" | awk -v RS=':' -v ORS=":" '!a[$1]++{if (NR > 1) printf ORS; printf $a[$1]}')
 
 pathAppend() {
   # Only adds to the path if it's not already there
@@ -9,6 +6,9 @@ pathAppend() {
     PATH=$PATH:$1
   fi
 }
+
+# Remove duplicate entries from PATH:
+PATH=$(echo "$PATH" | awk -v RS=':' -v ORS=":" '!a[$1]++{if (NR > 1) printf ORS; printf $a[$1]}')
 
 pathAppend "$HOME/.yadr/bin"
 pathAppend "$HOME/.yadr/bin/yadr"


### PR DESCRIPTION
See #690.

I converted `path` to `PATH` while at it. Is there a reason why it should be lowercase? I followed the general convention of having `PATH` uppercase. Let me know if I shouldn't.

I've also included @7Moses [command](https://github.com/skwp/dotfiles/issues/690#issue-131809694) to remove duplicate entries from $PATH in the comment. Didn't want to always run that command indadvertedly for all users.

What do you think, @7Moses, @skwp ?