### PR TITLE
Adding Docker support!

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docker-compose.yml
+Dockerfile
+bin/fix_macvim_external_display.sh
+bin/osx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:16.04
+LABEL maintainer="Luiz Filho <lfilho@gmail.com>"
+
+# Let the container know that there is no tty
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM xterm-256color
+
+# Bootstrapping packages needed for installation
+RUN \
+  apt-get update && \
+  apt-get install -yqq \
+    locales \
+    lsb-release \
+    software-properties-common && \
+  apt-get clean
+
+# Set locale to UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LANG en_US.UTF-8
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+  /usr/sbin/update-locale LANG=$LANG
+
+# Install dependencies
+# `universe` is needed for ruby
+# `security` is needed for fontconfig and fc-cache
+RUN \
+  add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe security" && \
+  add-apt-repository ppa:aacebedo/fasd && \
+  apt-get update && \
+  apt-get -yqq install \
+    autoconf \
+    build-essential \
+    curl \
+    fasd \
+    fontconfig \
+    git \
+    python \
+    python-setuptools \
+    python-dev \
+    ruby-full \
+    sudo \
+    tmux \
+    vim \
+    wget \
+    zsh && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install dotfiles
+COPY . /root/.yadr
+RUN cd /root/.yadr && rake install
+
+# Run a zsh session
+CMD [ "/bin/zsh" ]

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
   * More than 90 vim plugins, all under one roof, working together, each plugin researched and configured to be at its best, often with better shortcut keys.
   * Many zsh plugins, starting with the wonderful Prezto base, and adding a few niceties on top.
   * All things are vimized: irb, postgres command line, etc.
-  
+
 *Linux/Ubuntu is not supported! If it works, great. If it doesn't, please don't complain. You may need to install zsh if you don't already have it.*
+*That being said, check the Docker section below*
 
 ## Mailing List
 
@@ -281,6 +282,20 @@ of plugins above to learn more.
 * [Overriding vim settings with ~/.vimrc.after and friends](doc/vim/override.md)
 * [Adding your own vim plugins](doc/vim/manage_plugins.md)
 
+## Testing with Docker
+
+We can use Docker to test some changes in a **Linux** Container.
+
+Assuming your host system has Docker & Docker Compose properly installed, run:
+
+    docker-compose run dotfiles
+
+This will build the container image it never built it before (which may take a while -- future times will be faster) and then run a `zsh` session inside that container for you.
+There you can play around, test commands, aliases, etc.
+
+*Warning*: this repo is primarly OSX oriented. So any support for Linux can only be done with the help of the community.
+
+
 ## Misc
 
 * [Credits & Thanks](doc/credits.md)
@@ -316,11 +331,9 @@ brew uninstall vim
 rvm system do brew install vim --with-lua
 ```
 
-
 ### [Pry](http://pry.github.com/)
 
 Pry offers a much better out of the box IRB experience with colors, tab completion, and lots of other tricks. You can also use it
 as an actual debugger by installing [pry-nav](https://github.com/nixme/pry-nav).
 
 [Learn more about YADR's pry customizations and how to install](doc/pry.md)
-

--- a/Rakefile
+++ b/Rakefile
@@ -274,7 +274,7 @@ def install_prezto
   run %{ mkdir -p $HOME/.zsh.after }
   run %{ mkdir -p $HOME/.zsh.prompts }
 
-  if ENV["SHELL"].include? 'zsh' then
+  if "#{ENV['SHELL']}".include? 'zsh' then
     puts "Zsh is already configured as your shell of choice. Restart your session to load the new settings"
   else
     puts "Setting zsh as your default shell"

--- a/doc/credits.md
+++ b/doc/credits.md
@@ -23,4 +23,4 @@ Yadr is made possible by many awesome people, too many to list :) But here are a
  * Cleanup, auto installer: @[kylewest](https://github.com/kylewest)
  * Switch from oh-my-zsh to Presto: @[JeanMertz](https://github.com/JeanMertz)
  * Vundle migration: @[duhanebel](https://github.com/duhanebel)
-
+ * Docker support: @[lfilho](https://github.com/lfilho)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  dotfiles:
+    build:
+      context: .
+    image: yadr
+    volumes:
+      - ./:/root/.yadr/


### PR DESCRIPTION
Great news!

This PR introduces Docker to Yadr! A small step that opens many doors for us, IMHO.

With this in place, we can:
- Have more linux contributors contributing not only to Linux-specific support, but also to general vim and zsh stuff
- Have an automated CI build that tests the installation process, which will grant us more trust when making changes (breaking or not). (Having a "build passing"  badge in the README is also good marketing for the repo lol)

So, what do you think? :-)

*Note*: The linux installation you can see in the `Dockerfile` is not necessairly everything a linux user needs to smoothly run Yadr. That will have to come within time from the contributions of htis community. It was just the bare minimum setup to pass the installation without errors.