### PR TITLE
KeyRepeat on Sierra way too fast to be practical

### DIFF
--- a/bin/macos
+++ b/bin/macos
@@ -56,7 +56,8 @@ defaults write NSGlobalDomain AppleFontSmoothing -int 2
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 
 # Set a blazingly fast keyboard repeat rate
-defaults write NSGlobalDomain KeyRepeat -int 0
+defaults write NSGlobalDomain KeyRepeat -int 1
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
 
 # Disable auto-correct
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false


### PR DESCRIPTION
Looks like they've changed the scale in macOS Sierrra. `KeyRepeat -int 0` seems to be too impractical. I can't even hold backspace because it erases too much. Since you've taken this from another repo, it's worth referencing the same issue in that repo:

https://github.com/mathiasbynens/dotfiles/issues/687

![keyrepeat](https://user-images.githubusercontent.com/807110/29008228-c11ef4c2-7b45-11e7-8a78-1dd24fd046a2.gif)

Also, the terminal can't update as fast as the key repeats and only updates which ones have been typed/erased after you stopped pressing the key. I'm even having trouble editing this PR with the current setting. You can tweak it to a different value if you want.