### PR TITLE
fix(Rakefile) Remove --custom-icons flag to install macvim.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher ghi}
-  run %{brew install macvim --custom-icons --with-override-system-vim --with-lua --with-luajit}
+  run %{brew install macvim --with-override-system-vim --with-lua --with-luajit}
   puts
   puts
 end


### PR DESCRIPTION
Fix for #786 