### PR TITLE
vim override file location is vim/settings/*.vim

### DIFF
--- a/doc/vim/override.md
+++ b/doc/vim/override.md
@@ -1,3 +1,3 @@
 You may use `~/.vimrc.before` for settings like the __leader__ setting.
 You may use `~/.vimrc.after` (for those transitioning from janus) or `~/.yadr/vim/after/.vimrc.after` for any additional overrides/settings.
-If you didn't have janus before, it is recommended to just put it in `~/.yadr/vim/after` so you can better manage your overrides.
+If you didn't have janus before, it is recommended to just put it in `~/.yadr/vim/settings` so you can better manage your overrides.


### PR DESCRIPTION
I don't see files in vim/after/ directory are being sourced. 
Should the user overrides be stored in vim/settings directory instead? 