### PR TITLE
Update prompt_skwp_setup

### DIFF
--- a/zsh/prezto-themes/prompt_skwp_setup
+++ b/zsh/prezto-themes/prompt_skwp_setup
@@ -31,7 +31,7 @@ function prompt_skwp_precmd {
 function prompt_skwp_setup {
   setopt LOCAL_OPTIONS
   unsetopt XTRACE KSH_ARRAYS
-  prompt_opts=(cr percent subst)
+  prompt_opts=(cr percent sp subst)
 
   autoload -Uz add-zsh-hook
 


### PR DESCRIPTION
Because of changes in zsh 5.4.1, the last line gets swallowed when you cat anything. To confirm, try `echo -n hello-world`.

C.f. https://github.com/sorin-ionescu/prezto/commit/730fc4690e308208f591798ef992b9bb2f9e2134