### PR TITLE
fix missing if detecting buffer fugitive type

### DIFF
--- a/vim/settings/vim-fugitive.vim
+++ b/vim/settings/vim-fugitive.vim
@@ -3,7 +3,7 @@
 " parent directory. Here’s a mapping of .. to the above command, but
 " only for buffers containing a git blob or tree
 autocmd User fugitive
-  \ get(b:, 'fugitive_type', '') =~# '^\%(tree\|blob\)$' |
+  \ if get(b:, 'fugitive_type', '') =~# '^\%(tree\|blob\)$' |
   \   nnoremap <buffer> .. :edit %:h<CR> |
   \ endif
 


### PR DESCRIPTION
Was PR #811 reviewed?

I started getting a different error message on vim startup, different from issue #808.

```
Error detected while processing User Autocommands for "fugitive":              
E492: Not an editor command: get(b:, 'fugitive_type', '') =~# '^\%(tree\|blob\)$' |   nnoremap <buffer> .. :edit %:h<CR> | endif                               
```

Looking deeper, I noticed that the `if` was removed from `autocmd` command.

My vim version is 8.1.577 (brew macvim) 

I tested outside git repository and when on git repository opening tracked files, untracked and opening a tree object (to check when if condition is true)
`:Gedit 7726c3136f4863f8d0c765561e0ed0896d534a66` on this repository.

Best,
Pablo