### PR TITLE
zsh: Remove deprecated 'brew prune' command from alias

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -210,4 +210,4 @@ alias dbmd='spring rake db:migrate:down'
 alias dbmu='spring rake db:migrate:up'
 
 # Homebrew
-alias brewu='brew update  && brew upgrade && brew cleanup && brew prune && brew doctor'
+alias brewu='brew update && brew upgrade && brew cleanup && brew doctor'


### PR DESCRIPTION
Hi,
  This small PR removes deprecated 'brew prune' command from `brewu` alias.

  As per https://brew.sh/2019/01/09/homebrew-1.9.0/
`brew prune has been replaced by and is now run as part of brew cleanup.`
  Associated HomeBrew PR: https://github.com/Homebrew/brew/pull/5467

  Thanks!