### PR TITLE
Translate tmux -fg, -bg and -attr options into -style options

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -49,13 +49,10 @@ set-window-option -g mouse on
 # color scheme (styled as vim-powerline)
 set -g status-left-length 52
 set -g status-right-length 451
-set -g status-fg white
-set -g status-bg colour234
-set -g pane-border-fg colour245
-set -g pane-active-border-fg colour39
-set -g message-fg colour16
-set -g message-bg colour221
-set -g message-attr bold
+set -g status-style fg=white,bg=colour234
+set -g pane-border-style fg=colour245
+set -g pane-active-border-style fg=colour39
+set -g message-style fg=colour16,bg=colour221,bold
 set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
 set -g window-status-format '#[fg=colour235,bg=colour252,bold] #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W '
 set -g window-status-current-format '#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour228],} #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W #[fg=colour39,bg=colour234,nobold]⮀'


### PR DESCRIPTION
Some tmux config options were removed with tmux 2.9, so I updated them in accordance with https://github.com/tmux/tmux/wiki/FAQ#how-do-i-translate--fg--bg-and--attr-options-into--style-options.