### PR TITLE
Fix failing macvim installation on rake install

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,8 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher ghi}
-  run %{brew install macvim --with-override-system-vim --with-lua --with-luajit}
+  run %{brew tap macvim-dev/macvim}
+  run %{brew install --HEAD macvim-dev/macvim/macvim}
   puts
   puts
 end


### PR DESCRIPTION
Fix macvim installation failing since homebrew updates to not support options anymore.