### PR TITLE
Fix MacVim installation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -173,7 +173,7 @@ def install_homebrew
   puts "Installing Homebrew packages...There may be some warnings."
   puts "======================================================"
   run %{brew install zsh ctags git hub tmux reattach-to-user-namespace the_silver_searcher ghi}
-  run %{brew install macvim --with-override-system-vim --with-lua --with-luajit}
+  run %{brew install macvim}
   puts
   puts
 end


### PR DESCRIPTION
This PR fixes MacVim installation/update and intended to be an override for https://github.com/skwp/dotfiles/pull/822.

Homebrew Core maintains its own formula for MacVim which is actively maintained and normally is up to date. This [formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/macvim.rb) supports Lua and Python by default.

This is working just fine for some time already.