### PR TITLE
Update git dead link

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -16,7 +16,7 @@
   a = add                           # add
   chunkyadd = add --patch           # stage commits chunk by chunk
 
-  # via http://blog.apiaxle.com/post/handy-git-tips-to-stop-you-getting-fired/
+  # via http://philjackson.github.io/2013/04/07/handy-git-tips-to-stop-you-getting-fired.html
   snapshot = !git stash save "snapshot: $(date)" && git stash apply "stash@{0}"
   snapshots = !git stash list --grep snapshot
 


### PR DESCRIPTION
Closes #837.

According to [Web Archive](https://web.archive.org/web/20190419165317/http://blog.apiaxle.com/post/handy-git-tips-to-stop-you-getting-fired/l) [this](http://philjackson.github.io/2013/04/07/handy-git-tips-to-stop-you-getting-fired.html) is the correct link.