### PR TITLE
add snipmate settings

### DIFF
--- a/vim/settings/snipmate.vim
+++ b/vim/settings/snipmate.vim
@@ -1,0 +1,2 @@
+" Explicitly set g:snipMate.snippet_version to remove start up message
+let g:snipMate = { 'snippet_version' : 0 }


### PR DESCRIPTION
There's this annoying message whenever I start `vim`:
```
$ vim ~/.zshrc
The legacy SnipMate parser is deprecated. Please see :h SnipMate-deprecate.
Press ENTER or type command to continue
```

This is because SnipMate's legacy version, as stated in `:h SnipMate-deprecate`:

> The legacy parser, version 0, is deprecated. It is currently still the default
> parser, but that will be changing. NOTE that switching which parser you use
> could require changes to your snippets--see the previous section.
> 
> To continue using the old parser, set g:snipMate.snippet_version (see
> SnipMate-options) to 0 in your vimrc.
> 
> Setting g:snipMate.snippet_version to either 0 or 1 will remove the start up
> message. One way this can be done--to use the new parser--is as follows:
> 
>     let g:snipMate = { 'snippet_version' : 1 }

This PR proposes a SnipMate settings file, in which the snippet version is set explicitly in order to remove the startup message. It is set to 0 as it's still the default version.