### PR TITLE
Avoid "ls: illegal option -- -"

### DIFF
--- a/zsh/prezto-override/zpreztorc
+++ b/zsh/prezto-override/zpreztorc
@@ -30,6 +30,7 @@ zstyle ':prezto:load' pmodule \
   'history' \
   'directory' \
   'spectrum' \
+  'gnu-utility' \
   'utility' \
   'completion' \
   'archive' \


### PR DESCRIPTION
Under certain configurations with coreutils installed via brew, you may see this in shells started inside tmux:

ls: illegal option -- -
usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]

This is a known issue in prezto: sorin-ionescu/prezto#966

Modify zsh/prezto-override/zpreztorc to make that go away.