### PR TITLE
#887 - Warning in terminal regarding egrep obsolescence

### DIFF
--- a/zsh/0_path.zsh
+++ b/zsh/0_path.zsh
@@ -2,7 +2,7 @@
 
 pathAppend() {
   # Only adds to the path if it's not already there
-  if ! echo $PATH | egrep -q "(^|:)$1($|:)" ; then
+  if ! echo $PATH | grep -E -q "(^|:)$1($|:)" ; then
     PATH=$PATH:$1
   fi
 }


### PR DESCRIPTION
* Update use of `egrep` to `grep -E`, I tested on my mac, but not sure when `grep -E` was added to the BSD version.